### PR TITLE
Merge webserver def with its default value

### DIFF
--- a/docs/kind-webserver.md
+++ b/docs/kind-webserver.md
@@ -15,7 +15,7 @@ zbuildfiles with webserver types have following structure:
 ```yaml
 kind: webserver
 
-webserver: <string> # (default: nginx)
+type: <string> # (default: nginx)
 system_packages: <map[string]string>
 config_file: <string> # (required)
 healthcheck: <bool> # (default: true)

--- a/pkg/defkinds/nodejs/definition.go
+++ b/pkg/defkinds/nodejs/definition.go
@@ -67,6 +67,10 @@ func NewKind(genericDef *builddef.BuildDef) (Definition, error) {
 		return def, err
 	}
 
+	if def.Webserver != nil {
+		*def.Webserver = webserver.DefaultDefinition().Merge(*def.Webserver)
+	}
+
 	if def.Version != "" && def.BaseImage != "" {
 		return def, xerrors.Errorf("you can't provide both version and base image parameters at the same time")
 	}

--- a/pkg/defkinds/nodejs/testdata/build/frontend.yml
+++ b/pkg/defkinds/nodejs/testdata/build/frontend.yml
@@ -14,6 +14,6 @@ stages:
       .env.prod: .env
 
 webserver:
-  webserver: nginx
+  type: nginx
   config_file: nginx.conf
   healthcheck: true

--- a/pkg/defkinds/nodejs/testdata/build/zbuild.yml
+++ b/pkg/defkinds/nodejs/testdata/build/zbuild.yml
@@ -2,7 +2,7 @@ kind: nodejs
 version: 12
 
 webserver:
-  webserver: nginx
+  type: nginx
   config_file: nginx.conf
   healthcheck: true
 

--- a/pkg/defkinds/nodejs/testdata/locks/with-webserver.yml
+++ b/pkg/defkinds/nodejs/testdata/locks/with-webserver.yml
@@ -3,6 +3,6 @@ version: 12
 frontend: true
 
 webserver:
-  webserver: nginx
+  type: nginx
   config_file: nginx.conf
   healthcheck: true

--- a/pkg/defkinds/php/definition.go
+++ b/pkg/defkinds/php/definition.go
@@ -77,6 +77,10 @@ func NewKind(genericDef *builddef.BuildDef) (Definition, error) {
 		return def, err
 	}
 
+	if def.Webserver != nil {
+		*def.Webserver = webserver.DefaultDefinition().Merge(*def.Webserver)
+	}
+
 	def.MajMinVersion = extractMajMinVersion(def.Version)
 
 	if def.BaseImage == "" {

--- a/pkg/defkinds/php/testdata/build/with-webserver.yml
+++ b/pkg/defkinds/php/testdata/build/with-webserver.yml
@@ -4,7 +4,7 @@ version: 7.4
 fpm: true
 
 webserver:
-  webserver: nginx
+  type: nginx
   healthcheck: true
   assets:
     - from: /app/public

--- a/pkg/defkinds/webserver/builder.go
+++ b/pkg/defkinds/webserver/builder.go
@@ -58,7 +58,7 @@ func (h *WebserverHandler) Build(
 
 	state, err = llbutils.InstallSystemPackages(state, llbutils.APT, def.Locks.SystemPackages)
 
-	if def.ConfigFile != "" {
+	if def.ConfigFile != nil && *def.ConfigFile != "" {
 		state = h.copyConfigFile(state, def, buildOpts)
 	}
 
@@ -78,7 +78,7 @@ func (h *WebserverHandler) copyConfigFile(
 	buildOpts builddef.BuildOpts,
 ) llb.State {
 	configFileSrc := llbutils.BuildContext(buildOpts.ContextName,
-		llb.IncludePatterns([]string{def.ConfigFile}),
+		llb.IncludePatterns([]string{*def.ConfigFile}),
 		llb.LocalUniqueID(buildOpts.LocalUniqueID),
 		llb.SessionID(buildOpts.SessionID),
 		llb.SharedKeyHint(SharedKeys.ConfigFile),
@@ -86,7 +86,7 @@ func (h *WebserverHandler) copyConfigFile(
 
 	return llbutils.Copy(
 		configFileSrc,
-		def.ConfigFile,
+		*def.ConfigFile,
 		state,
 		def.Type.ConfigPath(),
 		fileOwner,

--- a/pkg/defkinds/webserver/definition.go
+++ b/pkg/defkinds/webserver/definition.go
@@ -50,7 +50,7 @@ func NewKind(genericDef *builddef.BuildDef) (Definition, error) {
 }
 
 type Definition struct {
-	Type           WebserverType     `mapstructure:"webserver"`
+	Type           WebserverType     `mapstructure:"type"`
 	SystemPackages map[string]string `mapstructure:"system_packages"`
 	ConfigFile     string            `mapstructure:"config_file"`
 	Healthcheck    bool              `mapstructure:"healthcheck"`
@@ -68,7 +68,7 @@ func (def Definition) Validate() error {
 
 func (def Definition) RawConfig() map[string]interface{} {
 	return map[string]interface{}{
-		"webserver":       def.Type,
+		"type":            def.Type,
 		"system_packages": def.SystemPackages,
 		"config_file":     def.ConfigFile,
 		"healthcheck":     def.Healthcheck,

--- a/pkg/defkinds/webserver/definition_test.go
+++ b/pkg/defkinds/webserver/definition_test.go
@@ -18,13 +18,15 @@ type newDefinitionTC struct {
 }
 
 func initSuccessfullyParseRawDefinitionTC() newDefinitionTC {
+	configFile := "./docker/nginx.conf"
+	healthcheck := true
 	return newDefinitionTC{
 		file:     "testdata/locks/definition.yml",
 		lockFile: "testdata/locks/definition.lock",
 		expected: webserver.Definition{
 			Type:        "nginx",
-			ConfigFile:  "./docker/nginx.conf",
-			Healthcheck: true,
+			ConfigFile:  &configFile,
+			Healthcheck: &healthcheck,
 			SystemPackages: map[string]string{
 				"curl": "*",
 			},

--- a/pkg/defkinds/webserver/testdata/build/with-assets.yml
+++ b/pkg/defkinds/webserver/testdata/build/with-assets.yml
@@ -1,5 +1,5 @@
 kind: webserver
-webserver: nginx
+type: nginx
 
 assets:
   - from: /app/public

--- a/pkg/defkinds/webserver/testdata/build/zbuild.yml
+++ b/pkg/defkinds/webserver/testdata/build/zbuild.yml
@@ -1,5 +1,5 @@
 kind: webserver
-webserver: nginx
+type: nginx
 
 healthcheck: true
 system_packages:

--- a/pkg/defkinds/webserver/testdata/locks/definition.yml
+++ b/pkg/defkinds/webserver/testdata/locks/definition.yml
@@ -1,5 +1,5 @@
 kind: webserver
-webserver: nginx
+type: nginx
 
 healthcheck: true
 system_packages:


### PR DESCRIPTION
When the webserver definition is unmarshaled from another kind, the
default values were not kept and for instance, webserver healthchecks
were not enabled by default. The webserver Definition now have a Merge()
method to solve that issue.

Depends on #16.