### PR TITLE
Introduce php.ExtensionSet struct

### DIFF
--- a/pkg/defkinds/php/builder_test.go
+++ b/pkg/defkinds/php/builder_test.go
@@ -315,7 +315,10 @@ func TestDebugConfig(t *testing.T) {
 
 			expected := loadTestdata(t, tc.expected)
 			if expected != string(raw) {
-				t.Fatalf("Expected: %s\nGot: %s", expected, string(raw))
+				tempfile := newTempFile(t)
+				writeTestdata(t, tempfile, string(raw))
+
+				t.Fatalf("Expected: <%s>\nGot: <%s>", tc.expected, tempfile)
 			}
 		})
 	}

--- a/pkg/defkinds/php/definition_test.go
+++ b/pkg/defkinds/php/definition_test.go
@@ -44,7 +44,7 @@ func initSuccessfullyParseRawDefinitionWithoutStagesTC() newDefinitionTC {
 				ExternalFiles:  []llbutils.ExternalFile{},
 				SystemPackages: map[string]string{},
 				FPM:            &isFPM,
-				Extensions: map[string]string{
+				Extensions: &php.ExtensionSet{
 					"intl":      "*",
 					"pdo_mysql": "*",
 					"soap":      "*",
@@ -135,7 +135,7 @@ func initSuccessfullyParseRawDefinitionWithStagesTC() newDefinitionTC {
 				ExternalFiles:  []llbutils.ExternalFile{},
 				SystemPackages: map[string]string{},
 				FPM:            &isFPM,
-				Extensions: map[string]string{
+				Extensions: &php.ExtensionSet{
 					"intl":      "*",
 					"pdo_mysql": "*",
 					"soap":      "*",
@@ -285,7 +285,7 @@ func initSuccessfullyResolveDefaultDevStageTC(t *testing.T, mockCtrl *gomock.Con
 				},
 				SystemPackages: map[string]string{},
 				FPM:            &isFPM,
-				Extensions: map[string]string{
+				Extensions: &php.ExtensionSet{
 					"intl":      "*",
 					"pdo_mysql": "*",
 					"soap":      "*",
@@ -350,7 +350,7 @@ func initSuccessfullyResolveWorkerStageTC(t *testing.T, mockCtrl *gomock.Control
 				},
 				FPM:     &isNotFPM,
 				Command: &workerCmd,
-				Extensions: map[string]string{
+				Extensions: &php.ExtensionSet{
 					"mbstring": "*",
 					"zip":      "*",
 				},
@@ -427,7 +427,7 @@ func initRemoveDefaultExtensionsTC(t *testing.T, mockCtrl *gomock.Controller) re
 					"libzip-dev":    "*",
 				},
 				FPM: &fpm,
-				Extensions: map[string]string{
+				Extensions: &php.ExtensionSet{
 					"zip":        "*",
 					"mbstring":   "*",
 					"reflection": "*",
@@ -490,7 +490,7 @@ func initPreservePredefinedExtensionConstraintsTC(t *testing.T, mockCtrl *gomock
 					"libzip-dev":   "*",
 				},
 				FPM: &fpm,
-				Extensions: map[string]string{
+				Extensions: &php.ExtensionSet{
 					"zip":   "*",
 					"redis": "^5.1",
 				},
@@ -961,7 +961,7 @@ func emptyStage() php.Stage {
 	return php.Stage{
 		ExternalFiles:  []llbutils.ExternalFile{},
 		SystemPackages: map[string]string{},
-		Extensions:     map[string]string{},
+		Extensions:     &php.ExtensionSet{},
 		GlobalDeps:     map[string]string{},
 		ConfigFiles:    php.PHPConfigFiles{},
 		Sources:        []string{},
@@ -1171,19 +1171,19 @@ func initMergeExtensionsWithBaseTC() mergeStageTC {
 	return mergeStageTC{
 		base: func() php.Stage {
 			return php.Stage{
-				Extensions: map[string]string{
+				Extensions: &php.ExtensionSet{
 					"apcu": "*",
 				},
 			}
 		},
 		overriding: php.Stage{
-			Extensions: map[string]string{
+			Extensions: &php.ExtensionSet{
 				"opcache": "*",
 			},
 		},
 		expected: func() php.Stage {
 			s := emptyStage()
-			s.Extensions = map[string]string{
+			s.Extensions = &php.ExtensionSet{
 				"apcu":    "*",
 				"opcache": "*",
 			}
@@ -1198,13 +1198,13 @@ func initMergeExtensionsWithoutBaseTC() mergeStageTC {
 			return php.Stage{}
 		},
 		overriding: php.Stage{
-			Extensions: map[string]string{
+			Extensions: &php.ExtensionSet{
 				"opcache": "*",
 			},
 		},
 		expected: func() php.Stage {
 			s := emptyStage()
-			s.Extensions = map[string]string{
+			s.Extensions = &php.ExtensionSet{
 				"opcache": "*",
 			}
 			return s

--- a/pkg/defkinds/php/locks.go
+++ b/pkg/defkinds/php/locks.go
@@ -147,19 +147,19 @@ func (h *PHPHandler) updateStagesLocks(
 	return locks, nil
 }
 
-func (h *PHPHandler) lockExtensions(extensions map[string]string) (map[string]string, error) {
+func (h *PHPHandler) lockExtensions(extensions *ExtensionSet) (map[string]string, error) {
 	resolved := map[string]string{}
 	ctx := context.Background()
 
 	// Remove extensions installed by default as this would result in a build
 	// error otherwise.
-	for _, name := range preinstalledExtensions {
-		if _, ok := extensions[name]; ok {
-			delete(extensions, name)
+	for _, name := range extensions.Names() {
+		if _, ok := preinstalledExtensions[name]; ok {
+			extensions.Remove(name)
 		}
 	}
 
-	for extName, constraint := range extensions {
+	for extName, constraint := range extensions.Set() {
 		if isCoreExtension(extName) {
 			resolved[extName] = constraint
 			continue

--- a/pkg/defkinds/php/testdata/debug-config/dump-dev.yml
+++ b/pkg/defkinds/php/testdata/debug-config/dump-dev.yml
@@ -19,7 +19,7 @@ stage:
   fpm: true
   command: null
   extensions:
-    apcu: =5.1.17
+    apcu: 5.1.17
     ctype: '*'
     date: '*'
     dom: '*'

--- a/pkg/defkinds/php/testdata/debug-config/dump-prod.yml
+++ b/pkg/defkinds/php/testdata/debug-config/dump-prod.yml
@@ -19,7 +19,7 @@ stage:
   fpm: true
   command: null
   extensions:
-    apcu: '*'
+    apcu: 5.1.17
     ctype: '*'
     date: '*'
     hash: '*'

--- a/pkg/defkinds/php/testdata/debug-config/zbuild.yml
+++ b/pkg/defkinds/php/testdata/debug-config/zbuild.yml
@@ -9,7 +9,7 @@ global_deps:
 extensions:
     # @TODO: wrong version of this ext is pinned for prod stage
     # @TODO: check why ext requirements from composer.json aren't in the lockfile
-    apcu: "=5.1.17"
+    apcu: "5.1.17"
     intl: "*"
     pdo_pgsql: "*"
 


### PR DESCRIPTION
The infered extensions were overwriting manually defined version
constraints. Because of that, PHP prod stages were always resolving the
latest version of APCu, even when a specific version was pinned in the
zbuildfile.

This new struct is used to properly add infered extensions without
overwriting manually defined version constraints.