### PR TITLE
Introduce builddef.VersionMap struct

### DIFF
--- a/pkg/builddef/builddef.go
+++ b/pkg/builddef/builddef.go
@@ -16,3 +16,78 @@ type BuildDef struct {
 type Locks interface {
 	RawLocks() ([]byte, error)
 }
+
+// VersionMap is a list of packages/extensions/etc... associated to version
+// constraints or resolved versions. It has dedicated methods to manipulate
+// items in the map, most notably Add() which can be used to add an item
+// without overwriting any preexisting value. This is used in specialized
+// defkind handlers to add infered items without rewriting manually-defined
+// values.
+type VersionMap map[string]string
+
+func (set *VersionMap) Add(name, val string, overwrite bool) {
+	if set == nil {
+		return
+	}
+	if _, ok := (*set)[name]; ok && !overwrite {
+		return
+	}
+	(*set)[name] = val
+}
+
+func (set *VersionMap) Remove(name string) {
+	if set == nil {
+		return
+	}
+	delete(*set, name)
+}
+
+func (set *VersionMap) Has(name string) bool {
+	if set == nil {
+		return false
+	}
+	_, ok := (*set)[name]
+	return ok
+}
+
+func (set *VersionMap) Names() []string {
+	if set == nil {
+		return []string{}
+	}
+
+	names := make([]string, 0, len(*set))
+	for extName := range *set {
+		names = append(names, extName)
+	}
+
+	return names
+}
+
+func (set *VersionMap) Map() map[string]string {
+	if set == nil {
+		return map[string]string{}
+	}
+	return *set
+}
+
+func (set *VersionMap) Copy() *VersionMap {
+	if set == nil {
+		return &VersionMap{}
+	}
+
+	new := VersionMap{}
+	for name, val := range *set {
+		new[name] = val
+	}
+
+	return &new
+}
+
+func (set *VersionMap) Merge(overriding *VersionMap) {
+	if set == nil || overriding == nil {
+		return
+	}
+	for name, val := range *overriding {
+		set.Add(name, val, true)
+	}
+}

--- a/pkg/builddef/builddef.go
+++ b/pkg/builddef/builddef.go
@@ -25,11 +25,18 @@ type Locks interface {
 // values.
 type VersionMap map[string]string
 
-func (set *VersionMap) Add(name, val string, overwrite bool) {
+func (set *VersionMap) Add(name, val string) {
 	if set == nil {
 		return
 	}
-	if _, ok := (*set)[name]; ok && !overwrite {
+	if _, ok := (*set)[name]; ok {
+		return
+	}
+	(*set)[name] = val
+}
+
+func (set *VersionMap) Overwrite(name, val string) {
+	if set == nil {
 		return
 	}
 	(*set)[name] = val
@@ -39,7 +46,9 @@ func (set *VersionMap) Remove(name string) {
 	if set == nil {
 		return
 	}
-	delete(*set, name)
+	if _, ok := (*set)[name]; ok {
+		delete(*set, name)
+	}
 }
 
 func (set *VersionMap) Has(name string) bool {
@@ -88,6 +97,6 @@ func (set *VersionMap) Merge(overriding *VersionMap) {
 		return
 	}
 	for name, val := range *overriding {
-		set.Add(name, val, true)
+		set.Overwrite(name, val)
 	}
 }

--- a/pkg/builddef/testdata/builddef_test.go
+++ b/pkg/builddef/testdata/builddef_test.go
@@ -1,0 +1,106 @@
+package builddef_test
+
+import (
+	"testing"
+
+	"github.com/NiR-/zbuild/pkg/builddef"
+	"github.com/go-test/deep"
+)
+
+func TestVersionMap(t *testing.T) {
+	testcases := map[string]struct {
+		initial  *builddef.VersionMap
+		modifier func(*builddef.VersionMap)
+		expected *builddef.VersionMap
+	}{
+		"Add() adds an item to the version map": {
+			initial: &builddef.VersionMap{},
+			modifier: func(versions *builddef.VersionMap) {
+				versions.Add("curl", "7.64.0-4")
+			},
+			expected: &builddef.VersionMap{
+				"curl": "7.64.0-4",
+			},
+		},
+		"Add() doesn't overwrite a previous value": {
+			initial: &builddef.VersionMap{
+				"curl": "*",
+			},
+			modifier: func(versions *builddef.VersionMap) {
+				versions.Add("curl", "7.64.0-4")
+			},
+			expected: &builddef.VersionMap{
+				"curl": "*",
+			},
+		},
+		"Add() does nothing when the map is nil": {
+			initial: nil,
+			modifier: func(versions *builddef.VersionMap) {
+				versions.Add("curl", "7.64.0-4")
+			},
+			expected: nil,
+		},
+		"Overwrite() replaces any previously defined value": {
+			initial: &builddef.VersionMap{
+				"curl": "*",
+			},
+			modifier: func(versions *builddef.VersionMap) {
+				versions.Overwrite("curl", "7.64.0-4")
+			},
+			expected: &builddef.VersionMap{
+				"curl": "7.64.0-4",
+			},
+		},
+		"Overwrite() adds a value if the key doesn't exist yet": {
+			initial: &builddef.VersionMap{},
+			modifier: func(versions *builddef.VersionMap) {
+				versions.Overwrite("curl", "7.64.0-4")
+			},
+			expected: &builddef.VersionMap{
+				"curl": "7.64.0-4",
+			},
+		},
+		"Overwrite() does nothing when the map is nil": {
+			initial: nil,
+			modifier: func(versions *builddef.VersionMap) {
+				versions.Overwrite("curl", "7.64.0-4")
+			},
+			expected: nil,
+		},
+		"Remove() does nothing if the item doesn't exist": {
+			initial: &builddef.VersionMap{},
+			modifier: func(versions *builddef.VersionMap) {
+				versions.Remove("curl")
+			},
+			expected: &builddef.VersionMap{},
+		},
+		"Remove() does remove an item when it exists": {
+			initial: &builddef.VersionMap{
+				"curl": "*",
+			},
+			modifier: func(versions *builddef.VersionMap) {
+				versions.Remove("curl")
+			},
+			expected: &builddef.VersionMap{},
+		},
+		"Remove() does nothing when the map is nil": {
+			initial: nil,
+			modifier: func(versions *builddef.VersionMap) {
+				versions.Remove("curl")
+			},
+			expected: nil,
+		},
+	}
+
+	for tcname := range testcases {
+		tc := testcases[tcname]
+		t.Run(tcname, func(t *testing.T) {
+			versions := tc.initial
+			tc.modifier(versions)
+
+			if diff := deep.Equal(versions, tc.expected); diff != nil {
+				t.Fatal(diff)
+			}
+		})
+	}
+}

--- a/pkg/defkinds/nodejs/builder.go
+++ b/pkg/defkinds/nodejs/builder.go
@@ -166,7 +166,7 @@ func (h *NodeJSHandler) buildNodeJS(
 	state = state.User("1000")
 	state = state.Dir("/app")
 
-	state = h.globalPackagesInstall(stageDef, state, buildOpts)
+	state = h.globalPackagesInstall(state, stageDef.GlobalPackages.Map(), buildOpts)
 
 	if *stageDef.Dev == false {
 		state = h.yarnInstall(stageDef, state, buildOpts)
@@ -242,16 +242,16 @@ func getEnv(src llb.State, name string) string {
 }
 
 func (h *NodeJSHandler) globalPackagesInstall(
-	stageDef StageDefinition,
 	state llb.State,
+	globalPackages map[string]string,
 	buildOpts builddef.BuildOpts,
 ) llb.State {
-	if len(stageDef.GlobalPackages) == 0 {
+	if len(globalPackages) == 0 {
 		return state
 	}
 
-	pkgs := make([]string, 0, len(stageDef.GlobalPackages))
-	for pkg, constraint := range stageDef.GlobalPackages {
+	pkgs := make([]string, 0, len(globalPackages))
+	for pkg, constraint := range globalPackages {
 		if constraint != "" && constraint != "*" {
 			pkg += "@" + constraint
 		}

--- a/pkg/defkinds/nodejs/definition.go
+++ b/pkg/defkinds/nodejs/definition.go
@@ -161,7 +161,7 @@ func (base Definition) Merge(overriding Definition) Definition {
 
 type Stage struct {
 	ExternalFiles  []llbutils.ExternalFile `mapstructure:"external_files"`
-	SystemPackages map[string]string       `mapstructure:"system_packages"`
+	SystemPackages *builddef.VersionMap    `mapstructure:"system_packages"`
 	GlobalPackages map[string]string       `mapstructure:"global_packages"`
 	BuildCommand   *string                 `mapstructure:"build_command"`
 	Command        *[]string               `mapstructure:"command"`
@@ -175,7 +175,7 @@ type Stage struct {
 func (s Stage) Copy() Stage {
 	new := Stage{
 		ExternalFiles:  make([]llbutils.ExternalFile, len(s.ExternalFiles)),
-		SystemPackages: map[string]string{},
+		SystemPackages: s.SystemPackages.Copy(),
 		GlobalPackages: map[string]string{},
 		BuildCommand:   s.BuildCommand,
 		Command:        s.Command,
@@ -189,9 +189,6 @@ func (s Stage) Copy() Stage {
 	copy(new.SourceDirs, s.SourceDirs)
 	copy(new.StatefulDirs, s.StatefulDirs)
 
-	for name, constraint := range s.SystemPackages {
-		new.SystemPackages[name] = constraint
-	}
 	for name, constraint := range s.GlobalPackages {
 		new.GlobalPackages[name] = constraint
 	}
@@ -207,10 +204,8 @@ func (s Stage) Merge(overriding Stage) Stage {
 	new.ExternalFiles = append(new.ExternalFiles, overriding.ExternalFiles...)
 	new.SourceDirs = append(new.SourceDirs, overriding.SourceDirs...)
 	new.StatefulDirs = append(new.StatefulDirs, overriding.StatefulDirs...)
+	new.SystemPackages.Merge(overriding.SystemPackages)
 
-	for name, constraint := range overriding.SystemPackages {
-		new.SystemPackages[name] = constraint
-	}
 	for name, constraint := range overriding.GlobalPackages {
 		new.GlobalPackages[name] = constraint
 	}

--- a/pkg/defkinds/nodejs/definition.go
+++ b/pkg/defkinds/nodejs/definition.go
@@ -162,7 +162,7 @@ func (base Definition) Merge(overriding Definition) Definition {
 type Stage struct {
 	ExternalFiles  []llbutils.ExternalFile `mapstructure:"external_files"`
 	SystemPackages *builddef.VersionMap    `mapstructure:"system_packages"`
-	GlobalPackages map[string]string       `mapstructure:"global_packages"`
+	GlobalPackages *builddef.VersionMap    `mapstructure:"global_packages"`
 	BuildCommand   *string                 `mapstructure:"build_command"`
 	Command        *[]string               `mapstructure:"command"`
 	ConfigFiles    map[string]string       `mapstructure:"config_files"`
@@ -176,7 +176,7 @@ func (s Stage) Copy() Stage {
 	new := Stage{
 		ExternalFiles:  make([]llbutils.ExternalFile, len(s.ExternalFiles)),
 		SystemPackages: s.SystemPackages.Copy(),
-		GlobalPackages: map[string]string{},
+		GlobalPackages: s.GlobalPackages.Copy(),
 		BuildCommand:   s.BuildCommand,
 		Command:        s.Command,
 		ConfigFiles:    map[string]string{},
@@ -189,9 +189,6 @@ func (s Stage) Copy() Stage {
 	copy(new.SourceDirs, s.SourceDirs)
 	copy(new.StatefulDirs, s.StatefulDirs)
 
-	for name, constraint := range s.GlobalPackages {
-		new.GlobalPackages[name] = constraint
-	}
 	for src, dst := range s.ConfigFiles {
 		new.ConfigFiles[src] = dst
 	}
@@ -205,10 +202,8 @@ func (s Stage) Merge(overriding Stage) Stage {
 	new.SourceDirs = append(new.SourceDirs, overriding.SourceDirs...)
 	new.StatefulDirs = append(new.StatefulDirs, overriding.StatefulDirs...)
 	new.SystemPackages.Merge(overriding.SystemPackages)
+	new.GlobalPackages.Merge(overriding.GlobalPackages)
 
-	for name, constraint := range overriding.GlobalPackages {
-		new.GlobalPackages[name] = constraint
-	}
 	for from, to := range overriding.ConfigFiles {
 		new.ConfigFiles[from] = to
 	}

--- a/pkg/defkinds/nodejs/definition_test.go
+++ b/pkg/defkinds/nodejs/definition_test.go
@@ -41,7 +41,7 @@ func initSuccessfullyParseRawDefinitionWithoutStagesTC() newDefinitionTC {
 						Owner: "1000:1000",
 					},
 				},
-				SystemPackages: map[string]string{
+				SystemPackages: &builddef.VersionMap{
 					"ca-certificates": "*",
 				},
 				ConfigFiles: map[string]string{
@@ -61,7 +61,7 @@ func initSuccessfullyParseRawDefinitionWithoutStagesTC() newDefinitionTC {
 					Dev:        &devStageDevMode,
 					Stage: nodejs.Stage{
 						ExternalFiles:  []llbutils.ExternalFile{},
-						SystemPackages: map[string]string{},
+						SystemPackages: &builddef.VersionMap{},
 						GlobalPackages: map[string]string{},
 						ConfigFiles:    map[string]string{},
 						SourceDirs:     []string{},
@@ -73,7 +73,7 @@ func initSuccessfullyParseRawDefinitionWithoutStagesTC() newDefinitionTC {
 					Dev:        &prodStageDevMode,
 					Stage: nodejs.Stage{
 						ExternalFiles:  []llbutils.ExternalFile{},
-						SystemPackages: map[string]string{},
+						SystemPackages: &builddef.VersionMap{},
 						GlobalPackages: map[string]string{},
 						ConfigFiles:    map[string]string{},
 						SourceDirs:     []string{},
@@ -99,7 +99,7 @@ func initSuccessfullyParseRawDefinitionWithStagesTC() newDefinitionTC {
 		expected: nodejs.Definition{
 			BaseStage: nodejs.Stage{
 				ExternalFiles:  []llbutils.ExternalFile{},
-				SystemPackages: map[string]string{},
+				SystemPackages: &builddef.VersionMap{},
 				ConfigFiles:    map[string]string{},
 				GlobalPackages: map[string]string{},
 				Healthcheck:    &baseStageHealthcheck,
@@ -114,7 +114,7 @@ func initSuccessfullyParseRawDefinitionWithStagesTC() newDefinitionTC {
 					Stage: nodejs.Stage{
 						Command:        &cmdDev,
 						ExternalFiles:  []llbutils.ExternalFile{},
-						SystemPackages: map[string]string{},
+						SystemPackages: &builddef.VersionMap{},
 						ConfigFiles:    map[string]string{},
 						GlobalPackages: map[string]string{},
 						SourceDirs:     []string{},
@@ -126,7 +126,7 @@ func initSuccessfullyParseRawDefinitionWithStagesTC() newDefinitionTC {
 					Stage: nodejs.Stage{
 						Command:        &cmdProd,
 						ExternalFiles:  []llbutils.ExternalFile{},
-						SystemPackages: map[string]string{},
+						SystemPackages: &builddef.VersionMap{},
 						ConfigFiles:    map[string]string{},
 						GlobalPackages: map[string]string{},
 						SourceDirs:     []string{},
@@ -229,7 +229,7 @@ func initSuccessfullyResolveDefaultDevStageTC() resolveStageTC {
 						Owner:       "1000:1000",
 					},
 				},
-				SystemPackages: map[string]string{
+				SystemPackages: &builddef.VersionMap{
 					"ca-certificates": "*",
 				},
 				GlobalPackages: map[string]string{},
@@ -257,7 +257,7 @@ func initSuccessfullyResolveWorkerStageTC() resolveStageTC {
 			Dev:       &devMode,
 			Stage: nodejs.Stage{
 				ExternalFiles:  []llbutils.ExternalFile{},
-				SystemPackages: map[string]string{},
+				SystemPackages: &builddef.VersionMap{},
 				ConfigFiles:    map[string]string{},
 				GlobalPackages: map[string]string{},
 				SourceDirs:     []string{},
@@ -364,7 +364,7 @@ type mergeStageTC struct {
 func emptyStage() nodejs.Stage {
 	return nodejs.Stage{
 		ExternalFiles:  []llbutils.ExternalFile{},
-		SystemPackages: map[string]string{},
+		SystemPackages: &builddef.VersionMap{},
 		GlobalPackages: map[string]string{},
 		ConfigFiles:    map[string]string{},
 		SourceDirs:     []string{},
@@ -445,19 +445,19 @@ func initMergeSystemPackagesWithBaseTC() mergeStageTC {
 	return mergeStageTC{
 		base: func() nodejs.Stage {
 			return nodejs.Stage{
-				SystemPackages: map[string]string{
+				SystemPackages: &builddef.VersionMap{
 					"curl": "*",
 				},
 			}
 		},
 		overriding: nodejs.Stage{
-			SystemPackages: map[string]string{
+			SystemPackages: &builddef.VersionMap{
 				"chromium": "*",
 			},
 		},
 		expected: func() nodejs.Stage {
 			s := emptyStage()
-			s.SystemPackages = map[string]string{
+			s.SystemPackages = &builddef.VersionMap{
 				"curl":     "*",
 				"chromium": "*",
 			}
@@ -472,13 +472,13 @@ func initMergeSystemPackagesWithoutBaseTC() mergeStageTC {
 			return nodejs.Stage{}
 		},
 		overriding: nodejs.Stage{
-			SystemPackages: map[string]string{
+			SystemPackages: &builddef.VersionMap{
 				"chromium": "*",
 			},
 		},
 		expected: func() nodejs.Stage {
 			s := emptyStage()
-			s.SystemPackages = map[string]string{
+			s.SystemPackages = &builddef.VersionMap{
 				"chromium": "*",
 			}
 			return s
@@ -1055,7 +1055,7 @@ func initMergeWebserverWithBaseTC() mergeDefinitionTC {
 			return nodejs.Definition{
 				Webserver: &webserver.Definition{
 					ConfigFile:     &expected,
-					SystemPackages: map[string]string{},
+					SystemPackages: &builddef.VersionMap{},
 				},
 				BaseStage: emptyStage(),
 				Stages:    nodejs.DerivedStageSet{},
@@ -1081,7 +1081,7 @@ func initMergeWebserverWithoutBaseTC() mergeDefinitionTC {
 			return nodejs.Definition{
 				Webserver: &webserver.Definition{
 					ConfigFile:     &expected,
-					SystemPackages: map[string]string{},
+					SystemPackages: &builddef.VersionMap{},
 				},
 				BaseStage: emptyStage(),
 				Stages:    nodejs.DerivedStageSet{},

--- a/pkg/defkinds/nodejs/definition_test.go
+++ b/pkg/defkinds/nodejs/definition_test.go
@@ -47,7 +47,7 @@ func initSuccessfullyParseRawDefinitionWithoutStagesTC() newDefinitionTC {
 				ConfigFiles: map[string]string{
 					".babelrc": ".babelrc",
 				},
-				GlobalPackages: map[string]string{},
+				GlobalPackages: &builddef.VersionMap{},
 				SourceDirs:     []string{"src/"},
 				StatefulDirs:   []string{"uploads/"},
 				Healthcheck:    &healthcheckDisabled,
@@ -62,7 +62,7 @@ func initSuccessfullyParseRawDefinitionWithoutStagesTC() newDefinitionTC {
 					Stage: nodejs.Stage{
 						ExternalFiles:  []llbutils.ExternalFile{},
 						SystemPackages: &builddef.VersionMap{},
-						GlobalPackages: map[string]string{},
+						GlobalPackages: &builddef.VersionMap{},
 						ConfigFiles:    map[string]string{},
 						SourceDirs:     []string{},
 						StatefulDirs:   []string{},
@@ -74,7 +74,7 @@ func initSuccessfullyParseRawDefinitionWithoutStagesTC() newDefinitionTC {
 					Stage: nodejs.Stage{
 						ExternalFiles:  []llbutils.ExternalFile{},
 						SystemPackages: &builddef.VersionMap{},
-						GlobalPackages: map[string]string{},
+						GlobalPackages: &builddef.VersionMap{},
 						ConfigFiles:    map[string]string{},
 						SourceDirs:     []string{},
 						StatefulDirs:   []string{},
@@ -101,7 +101,7 @@ func initSuccessfullyParseRawDefinitionWithStagesTC() newDefinitionTC {
 				ExternalFiles:  []llbutils.ExternalFile{},
 				SystemPackages: &builddef.VersionMap{},
 				ConfigFiles:    map[string]string{},
-				GlobalPackages: map[string]string{},
+				GlobalPackages: &builddef.VersionMap{},
 				Healthcheck:    &baseStageHealthcheck,
 				SourceDirs:     []string{},
 				StatefulDirs:   []string{},
@@ -116,7 +116,7 @@ func initSuccessfullyParseRawDefinitionWithStagesTC() newDefinitionTC {
 						ExternalFiles:  []llbutils.ExternalFile{},
 						SystemPackages: &builddef.VersionMap{},
 						ConfigFiles:    map[string]string{},
-						GlobalPackages: map[string]string{},
+						GlobalPackages: &builddef.VersionMap{},
 						SourceDirs:     []string{},
 						StatefulDirs:   []string{},
 					},
@@ -128,7 +128,7 @@ func initSuccessfullyParseRawDefinitionWithStagesTC() newDefinitionTC {
 						ExternalFiles:  []llbutils.ExternalFile{},
 						SystemPackages: &builddef.VersionMap{},
 						ConfigFiles:    map[string]string{},
-						GlobalPackages: map[string]string{},
+						GlobalPackages: &builddef.VersionMap{},
 						SourceDirs:     []string{},
 						StatefulDirs:   []string{},
 					},
@@ -232,7 +232,7 @@ func initSuccessfullyResolveDefaultDevStageTC() resolveStageTC {
 				SystemPackages: &builddef.VersionMap{
 					"ca-certificates": "*",
 				},
-				GlobalPackages: map[string]string{},
+				GlobalPackages: &builddef.VersionMap{},
 				SourceDirs:     []string{"src/"},
 				StatefulDirs:   []string{"uploads/"},
 				ConfigFiles:    map[string]string{".babelrc": ".babelrc"},
@@ -259,7 +259,7 @@ func initSuccessfullyResolveWorkerStageTC() resolveStageTC {
 				ExternalFiles:  []llbutils.ExternalFile{},
 				SystemPackages: &builddef.VersionMap{},
 				ConfigFiles:    map[string]string{},
-				GlobalPackages: map[string]string{},
+				GlobalPackages: &builddef.VersionMap{},
 				SourceDirs:     []string{},
 				StatefulDirs:   []string{},
 				Healthcheck:    &healthckeckDisabled,
@@ -365,7 +365,7 @@ func emptyStage() nodejs.Stage {
 	return nodejs.Stage{
 		ExternalFiles:  []llbutils.ExternalFile{},
 		SystemPackages: &builddef.VersionMap{},
-		GlobalPackages: map[string]string{},
+		GlobalPackages: &builddef.VersionMap{},
 		ConfigFiles:    map[string]string{},
 		SourceDirs:     []string{},
 		StatefulDirs:   []string{},
@@ -490,19 +490,19 @@ func initMergeGlobalPackagesWithBaseTC() mergeStageTC {
 	return mergeStageTC{
 		base: func() nodejs.Stage {
 			return nodejs.Stage{
-				GlobalPackages: map[string]string{
+				GlobalPackages: &builddef.VersionMap{
 					"puppeteer": "*",
 				},
 			}
 		},
 		overriding: nodejs.Stage{
-			GlobalPackages: map[string]string{
+			GlobalPackages: &builddef.VersionMap{
 				"api-platform/client-generator": "*",
 			},
 		},
 		expected: func() nodejs.Stage {
 			s := emptyStage()
-			s.GlobalPackages = map[string]string{
+			s.GlobalPackages = &builddef.VersionMap{
 				"puppeteer":                     "*",
 				"api-platform/client-generator": "*",
 			}
@@ -517,13 +517,13 @@ func initMergeGlobalPackagesWithoutBaseTC() mergeStageTC {
 			return nodejs.Stage{}
 		},
 		overriding: nodejs.Stage{
-			GlobalPackages: map[string]string{
+			GlobalPackages: &builddef.VersionMap{
 				"puppeteer": "*",
 			},
 		},
 		expected: func() nodejs.Stage {
 			s := emptyStage()
-			s.GlobalPackages = map[string]string{
+			s.GlobalPackages = &builddef.VersionMap{
 				"puppeteer": "*",
 			}
 			return s

--- a/pkg/defkinds/nodejs/locks.go
+++ b/pkg/defkinds/nodejs/locks.go
@@ -105,7 +105,7 @@ func (h *NodeJSHandler) updateStagesLocks(
 		stageLocks := StageLocks{}
 		stageLocks.SystemPackages, err = pkgSolver.ResolveVersions(
 			defLocks.BaseImage,
-			stage.SystemPackages)
+			stage.SystemPackages.Map())
 		if err != nil {
 			return nil, xerrors.Errorf("could not resolve versions of system packages to install: %w", err)
 		}

--- a/pkg/defkinds/php/builder.go
+++ b/pkg/defkinds/php/builder.go
@@ -178,7 +178,7 @@ func (h *PHPHandler) buildPHP(
 	state = state.AddEnv("COMPOSER_HOME", "/composer")
 
 	state = copyConfigFiles(stage, state, buildOpts)
-	state = globalComposerInstall(stage, state)
+	state = globalComposerInstall(state, stage.GlobalDeps.Map())
 
 	if !stage.Dev {
 		state = composerInstall(state, buildOpts)
@@ -332,11 +332,11 @@ func getEnv(src llb.State, name string) string {
 	return val
 }
 
-func globalComposerInstall(stage StageDefinition, state llb.State) llb.State {
-	deps := make([]string, 0, len(stage.GlobalDeps))
+func globalComposerInstall(state llb.State, globalDeps map[string]string) llb.State {
+	deps := make([]string, 0, len(globalDeps))
 	deps = append(deps, "hirak/prestissimo")
 
-	for dep, constraint := range stage.GlobalDeps {
+	for dep, constraint := range globalDeps {
 		if constraint != "" && constraint != "*" {
 			dep += ":" + constraint
 		}

--- a/pkg/defkinds/php/builder_test.go
+++ b/pkg/defkinds/php/builder_test.go
@@ -315,7 +315,10 @@ func TestDebugConfig(t *testing.T) {
 
 			expected := loadTestdata(t, tc.expected)
 			if expected != string(raw) {
-				t.Fatalf("Expected: %s\nGot: %s", expected, string(raw))
+				tempfile := newTempFile(t)
+				writeTestdata(t, tempfile, string(raw))
+
+				t.Fatalf("Expected: <%s>\nGot: <%s>", tc.expected, tempfile)
 			}
 		})
 	}

--- a/pkg/defkinds/php/definition.go
+++ b/pkg/defkinds/php/definition.go
@@ -439,11 +439,11 @@ func (def *Definition) ResolveStageDefinition(
 	}
 
 	if stageDef.Dev == false && *stageDef.FPM == true {
-		stageDef.Extensions.Add("apcu", "*", false)
-		stageDef.Extensions.Add("opcache", "*", false)
+		stageDef.Extensions.Add("apcu", "*")
+		stageDef.Extensions.Add("opcache", "*")
 	}
 	for name, constraint := range stageDef.PlatformReqs {
-		stageDef.Extensions.Add(name, constraint, false)
+		stageDef.Extensions.Add(name, constraint)
 	}
 
 	inferExtensions(&stageDef)
@@ -617,16 +617,16 @@ var preinstalledExtensions = map[string]struct{}{
 func inferExtensions(def *StageDefinition) {
 	// soap extension needs sockets extension to work properly
 	if def.Extensions.Has("soap") {
-		def.Extensions.Add("sockets", "*", false)
+		def.Extensions.Add("sockets", "*")
 	}
 
 	// Add zip extension if it's missing as it's used by composer to install packages.
-	def.Extensions.Add("zip", "*", false)
+	def.Extensions.Add("zip", "*")
 }
 
 func inferSystemPackages(def *StageDefinition) {
 	// Add libpcre by default, as most frameworks/CMSes are using regexp
-	def.SystemPackages.Add("libpcre3-dev", "*", false)
+	def.SystemPackages.Add("libpcre3-dev", "*")
 
 	for _, ext := range def.Extensions.Names() {
 		deps, ok := extensionsDeps[ext]
@@ -635,11 +635,11 @@ func inferSystemPackages(def *StageDefinition) {
 		}
 
 		for name, ver := range deps {
-			def.SystemPackages.Add(name, ver, false)
+			def.SystemPackages.Add(name, ver)
 		}
 	}
 
 	// Add unzip and git packages as they're used by Composer
-	def.SystemPackages.Add("unzip", "*", false)
-	def.SystemPackages.Add("git", "*", false)
+	def.SystemPackages.Add("unzip", "*")
+	def.SystemPackages.Add("git", "*")
 }

--- a/pkg/defkinds/php/definition.go
+++ b/pkg/defkinds/php/definition.go
@@ -57,7 +57,7 @@ func DefaultDefinition() Definition {
 			ExternalFiles:  []llbutils.ExternalFile{},
 			SystemPackages: map[string]string{},
 			FPM:            &fpm,
-			Extensions:     map[string]string{},
+			Extensions:     &builddef.VersionMap{},
 			GlobalDeps:     map[string]string{},
 			ComposerDumpFlags: &ComposerDumpFlags{
 				ClassmapAuthoritative: true,
@@ -194,7 +194,7 @@ type Stage struct {
 	SystemPackages    map[string]string       `mapstructure:"system_packages"`
 	FPM               *bool                   `mapstructure:",omitempty"`
 	Command           *[]string               `mapstructure:"command"`
-	Extensions        map[string]string       `mapstructure:"extensions"`
+	Extensions        *builddef.VersionMap    `mapstructure:"extensions"`
 	GlobalDeps        map[string]string       `mapstructure:"global_deps"`
 	ConfigFiles       PHPConfigFiles          `mapstructure:"config_files"`
 	ComposerDumpFlags *ComposerDumpFlags      `mapstructure:"composer_dump"`
@@ -211,7 +211,7 @@ func (s Stage) Copy() Stage {
 		SystemPackages:    map[string]string{},
 		FPM:               s.FPM,
 		Command:           s.Command,
-		Extensions:        map[string]string{},
+		Extensions:        s.Extensions.Copy(),
 		GlobalDeps:        map[string]string{},
 		ConfigFiles:       s.ConfigFiles.Copy(),
 		ComposerDumpFlags: s.ComposerDumpFlags,
@@ -231,9 +231,6 @@ func (s Stage) Copy() Stage {
 	for name, constraint := range s.SystemPackages {
 		new.SystemPackages[name] = constraint
 	}
-	for name, constraint := range s.Extensions {
-		new.Extensions[name] = constraint
-	}
 	for name, constraint := range s.GlobalDeps {
 		new.GlobalDeps[name] = constraint
 	}
@@ -250,6 +247,7 @@ func (s Stage) Merge(overriding Stage) Stage {
 	new.Integrations = append(new.Integrations, overriding.Integrations...)
 	new.StatefulDirs = append(new.StatefulDirs, overriding.StatefulDirs...)
 	new.PostInstall = append(new.PostInstall, overriding.PostInstall...)
+	new.Extensions.Merge(overriding.Extensions)
 
 	for name, constraint := range overriding.SystemPackages {
 		new.SystemPackages[name] = constraint
@@ -261,9 +259,6 @@ func (s Stage) Merge(overriding Stage) Stage {
 	if overriding.Command != nil {
 		cmd := *overriding.Command
 		new.Command = &cmd
-	}
-	for name, constraint := range overriding.Extensions {
-		new.Extensions[name] = constraint
 	}
 	for name, constraint := range overriding.GlobalDeps {
 		new.GlobalDeps[name] = constraint
@@ -454,13 +449,11 @@ func (def *Definition) ResolveStageDefinition(
 	}
 
 	if stageDef.Dev == false && *stageDef.FPM == true {
-		stageDef.Extensions["apcu"] = "*"
-		stageDef.Extensions["opcache"] = "*"
+		stageDef.Extensions.Add("apcu", "*", false)
+		stageDef.Extensions.Add("opcache", "*", false)
 	}
 	for name, constraint := range stageDef.PlatformReqs {
-		if _, ok := stageDef.Extensions[name]; !ok {
-			stageDef.Extensions[name] = constraint
-		}
+		stageDef.Extensions.Add(name, constraint, false)
 	}
 
 	inferExtensions(&stageDef)
@@ -595,54 +588,50 @@ func addIntegrations(stageDef *StageDefinition) error {
 //
 // This list has been obtained using:
 // docker run --rm -t php:7.2-fpm-buster php -r 'var_dump(get_loaded_extensions());'
-var preinstalledExtensions = []string{
-	"core",
-	"ctype",
-	"curl",
-	"date",
-	"dom",
-	"fileinfo",
-	"filter",
-	"ftp",
-	"hash",
-	"iconv",
-	"json",
-	"libxml",
-	"mbstring",
-	"mysqlnd",
-	"openssl",
-	"pcre",
-	"pdo",
-	"pdo_sqlite",
-	"phar",
-	"posix",
-	"readline",
-	"reflection",
-	"session",
-	"simplexml",
-	"sodium",
-	"spl",
-	"sqlite3",
-	"standard",
-	"tokenizer",
-	"xml",
-	"xmlreader",
-	"xmlwriter",
-	"zlib",
+var preinstalledExtensions = map[string]struct{}{
+	"core":       struct{}{},
+	"ctype":      struct{}{},
+	"curl":       struct{}{},
+	"date":       struct{}{},
+	"dom":        struct{}{},
+	"fileinfo":   struct{}{},
+	"filter":     struct{}{},
+	"ftp":        struct{}{},
+	"hash":       struct{}{},
+	"iconv":      struct{}{},
+	"json":       struct{}{},
+	"libxml":     struct{}{},
+	"mbstring":   struct{}{},
+	"mysqlnd":    struct{}{},
+	"openssl":    struct{}{},
+	"pcre":       struct{}{},
+	"pdo":        struct{}{},
+	"pdo_sqlite": struct{}{},
+	"phar":       struct{}{},
+	"posix":      struct{}{},
+	"readline":   struct{}{},
+	"reflection": struct{}{},
+	"session":    struct{}{},
+	"simplexml":  struct{}{},
+	"sodium":     struct{}{},
+	"spl":        struct{}{},
+	"sqlite3":    struct{}{},
+	"standard":   struct{}{},
+	"tokenizer":  struct{}{},
+	"xml":        struct{}{},
+	"xmlreader":  struct{}{},
+	"xmlwriter":  struct{}{},
+	"zlib":       struct{}{},
 }
 
 func inferExtensions(def *StageDefinition) {
 	// soap extension needs sockets extension to work properly
-	if _, ok := def.Extensions["soap"]; ok {
-		if _, ok := def.Extensions["sockets"]; !ok {
-			def.Extensions["sockets"] = "*"
-		}
+	if def.Extensions.Has("soap") {
+		def.Extensions.Add("sockets", "*", false)
 	}
 
 	// Add zip extension if it's missing as it's used by composer to install packages.
-	if _, ok := def.Extensions["zip"]; !ok {
-		def.Extensions["zip"] = "*"
-	}
+	def.Extensions.Add("zip", "*", false)
 }
 
 func inferSystemPackages(def *StageDefinition) {
@@ -650,7 +639,7 @@ func inferSystemPackages(def *StageDefinition) {
 		"libpcre3-dev": "*",
 	}
 
-	for ext := range def.Extensions {
+	for _, ext := range def.Extensions.Names() {
 		deps, ok := extensionsDeps[ext]
 		if !ok {
 			continue
@@ -662,6 +651,7 @@ func inferSystemPackages(def *StageDefinition) {
 	}
 
 	// Add unzip and git packages as they're used by Composer
+	// @TODO: use a struct like ExtensionSet to not overwrite unzip/git reqs
 	if _, ok := def.SystemPackages["unzip"]; !ok {
 		systemPackages["unzip"] = "*"
 	}

--- a/pkg/defkinds/php/definition_test.go
+++ b/pkg/defkinds/php/definition_test.go
@@ -44,7 +44,7 @@ func initSuccessfullyParseRawDefinitionWithoutStagesTC() newDefinitionTC {
 				ExternalFiles:  []llbutils.ExternalFile{},
 				SystemPackages: map[string]string{},
 				FPM:            &isFPM,
-				Extensions: map[string]string{
+				Extensions: &builddef.VersionMap{
 					"intl":      "*",
 					"pdo_mysql": "*",
 					"soap":      "*",
@@ -135,7 +135,7 @@ func initSuccessfullyParseRawDefinitionWithStagesTC() newDefinitionTC {
 				ExternalFiles:  []llbutils.ExternalFile{},
 				SystemPackages: map[string]string{},
 				FPM:            &isFPM,
-				Extensions: map[string]string{
+				Extensions: &builddef.VersionMap{
 					"intl":      "*",
 					"pdo_mysql": "*",
 					"soap":      "*",
@@ -285,7 +285,7 @@ func initSuccessfullyResolveDefaultDevStageTC(t *testing.T, mockCtrl *gomock.Con
 				},
 				SystemPackages: map[string]string{},
 				FPM:            &isFPM,
-				Extensions: map[string]string{
+				Extensions: &builddef.VersionMap{
 					"intl":      "*",
 					"pdo_mysql": "*",
 					"soap":      "*",
@@ -350,7 +350,7 @@ func initSuccessfullyResolveWorkerStageTC(t *testing.T, mockCtrl *gomock.Control
 				},
 				FPM:     &isNotFPM,
 				Command: &workerCmd,
-				Extensions: map[string]string{
+				Extensions: &builddef.VersionMap{
 					"mbstring": "*",
 					"zip":      "*",
 				},
@@ -427,7 +427,7 @@ func initRemoveDefaultExtensionsTC(t *testing.T, mockCtrl *gomock.Controller) re
 					"libzip-dev":    "*",
 				},
 				FPM: &fpm,
-				Extensions: map[string]string{
+				Extensions: &builddef.VersionMap{
 					"zip":        "*",
 					"mbstring":   "*",
 					"reflection": "*",
@@ -490,7 +490,7 @@ func initPreservePredefinedExtensionConstraintsTC(t *testing.T, mockCtrl *gomock
 					"libzip-dev":   "*",
 				},
 				FPM: &fpm,
-				Extensions: map[string]string{
+				Extensions: &builddef.VersionMap{
 					"zip":   "*",
 					"redis": "^5.1",
 				},
@@ -961,7 +961,7 @@ func emptyStage() php.Stage {
 	return php.Stage{
 		ExternalFiles:  []llbutils.ExternalFile{},
 		SystemPackages: map[string]string{},
-		Extensions:     map[string]string{},
+		Extensions:     &builddef.VersionMap{},
 		GlobalDeps:     map[string]string{},
 		ConfigFiles:    php.PHPConfigFiles{},
 		Sources:        []string{},
@@ -1171,19 +1171,19 @@ func initMergeExtensionsWithBaseTC() mergeStageTC {
 	return mergeStageTC{
 		base: func() php.Stage {
 			return php.Stage{
-				Extensions: map[string]string{
+				Extensions: &builddef.VersionMap{
 					"apcu": "*",
 				},
 			}
 		},
 		overriding: php.Stage{
-			Extensions: map[string]string{
+			Extensions: &builddef.VersionMap{
 				"opcache": "*",
 			},
 		},
 		expected: func() php.Stage {
 			s := emptyStage()
-			s.Extensions = map[string]string{
+			s.Extensions = &builddef.VersionMap{
 				"apcu":    "*",
 				"opcache": "*",
 			}
@@ -1198,13 +1198,13 @@ func initMergeExtensionsWithoutBaseTC() mergeStageTC {
 			return php.Stage{}
 		},
 		overriding: php.Stage{
-			Extensions: map[string]string{
+			Extensions: &builddef.VersionMap{
 				"opcache": "*",
 			},
 		},
 		expected: func() php.Stage {
 			s := emptyStage()
-			s.Extensions = map[string]string{
+			s.Extensions = &builddef.VersionMap{
 				"opcache": "*",
 			}
 			return s

--- a/pkg/defkinds/php/definition_test.go
+++ b/pkg/defkinds/php/definition_test.go
@@ -49,7 +49,7 @@ func initSuccessfullyParseRawDefinitionWithoutStagesTC() newDefinitionTC {
 					"pdo_mysql": "*",
 					"soap":      "*",
 				},
-				GlobalDeps: map[string]string{},
+				GlobalDeps: &builddef.VersionMap{},
 				ConfigFiles: php.PHPConfigFiles{
 					IniFile:       &iniFile,
 					FPMConfigFile: &fpmConfigFile,
@@ -140,7 +140,7 @@ func initSuccessfullyParseRawDefinitionWithStagesTC() newDefinitionTC {
 					"pdo_mysql": "*",
 					"soap":      "*",
 				},
-				GlobalDeps: map[string]string{},
+				GlobalDeps: &builddef.VersionMap{},
 				ConfigFiles: php.PHPConfigFiles{
 					FPMConfigFile: &fpmConfigFile,
 				},
@@ -290,7 +290,7 @@ func initSuccessfullyResolveDefaultDevStageTC(t *testing.T, mockCtrl *gomock.Con
 					"pdo_mysql": "*",
 					"soap":      "*",
 				},
-				GlobalDeps:   map[string]string{},
+				GlobalDeps:   &builddef.VersionMap{},
 				Sources:      []string{"./src"},
 				StatefulDirs: []string{"./public/uploads"},
 				ConfigFiles: php.PHPConfigFiles{
@@ -354,7 +354,7 @@ func initSuccessfullyResolveWorkerStageTC(t *testing.T, mockCtrl *gomock.Control
 					"mbstring": "*",
 					"zip":      "*",
 				},
-				GlobalDeps: map[string]string{},
+				GlobalDeps: &builddef.VersionMap{},
 				ComposerDumpFlags: &php.ComposerDumpFlags{
 					APCU:                  false,
 					ClassmapAuthoritative: true,
@@ -438,7 +438,7 @@ func initRemoveDefaultExtensionsTC(t *testing.T, mockCtrl *gomock.Controller) re
 					"json":       "*",
 					"session":    "*",
 				},
-				GlobalDeps:  map[string]string{},
+				GlobalDeps:  &builddef.VersionMap{},
 				ConfigFiles: php.PHPConfigFiles{},
 				ComposerDumpFlags: &php.ComposerDumpFlags{
 					ClassmapAuthoritative: true,
@@ -494,7 +494,7 @@ func initPreservePredefinedExtensionConstraintsTC(t *testing.T, mockCtrl *gomock
 					"zip":   "*",
 					"redis": "^5.1",
 				},
-				GlobalDeps:  map[string]string{},
+				GlobalDeps:  &builddef.VersionMap{},
 				ConfigFiles: php.PHPConfigFiles{},
 				ComposerDumpFlags: &php.ComposerDumpFlags{
 					ClassmapAuthoritative: true,
@@ -962,7 +962,7 @@ func emptyStage() php.Stage {
 		ExternalFiles:  []llbutils.ExternalFile{},
 		SystemPackages: &builddef.VersionMap{},
 		Extensions:     &builddef.VersionMap{},
-		GlobalDeps:     map[string]string{},
+		GlobalDeps:     &builddef.VersionMap{},
 		ConfigFiles:    php.PHPConfigFiles{},
 		Sources:        []string{},
 		Integrations:   []string{},
@@ -1505,20 +1505,20 @@ func initMergeGlobalDepsWithBaseTC() mergeStageTC {
 	return mergeStageTC{
 		base: func() php.Stage {
 			return php.Stage{
-				GlobalDeps: map[string]string{
+				GlobalDeps: &builddef.VersionMap{
 					"symfony/flex": "*",
 				},
 			}
 		},
 		overriding: php.Stage{
-			GlobalDeps: map[string]string{
+			GlobalDeps: &builddef.VersionMap{
 				"symfony/flex":      "1.6.0",
 				"hirak/prestissimo": "0.3.9",
 			},
 		},
 		expected: func() php.Stage {
 			stage := emptyStage()
-			stage.GlobalDeps = map[string]string{
+			stage.GlobalDeps = &builddef.VersionMap{
 				"symfony/flex":      "1.6.0",
 				"hirak/prestissimo": "0.3.9",
 			}
@@ -1532,18 +1532,18 @@ func initMergeGlobalDepsWithoutBaseTC() mergeStageTC {
 	return mergeStageTC{
 		base: func() php.Stage {
 			return php.Stage{
-				GlobalDeps: map[string]string{},
+				GlobalDeps: &builddef.VersionMap{},
 			}
 		},
 		overriding: php.Stage{
-			GlobalDeps: map[string]string{
+			GlobalDeps: &builddef.VersionMap{
 				"symfony/flex":      "1.6.0",
 				"hirak/prestissimo": "0.3.9",
 			},
 		},
 		expected: func() php.Stage {
 			stage := emptyStage()
-			stage.GlobalDeps = map[string]string{
+			stage.GlobalDeps = &builddef.VersionMap{
 				"symfony/flex":      "1.6.0",
 				"hirak/prestissimo": "0.3.9",
 			}

--- a/pkg/defkinds/php/definition_test.go
+++ b/pkg/defkinds/php/definition_test.go
@@ -42,7 +42,7 @@ func initSuccessfullyParseRawDefinitionWithoutStagesTC() newDefinitionTC {
 		expected: php.Definition{
 			BaseStage: php.Stage{
 				ExternalFiles:  []llbutils.ExternalFile{},
-				SystemPackages: map[string]string{},
+				SystemPackages: &builddef.VersionMap{},
 				FPM:            &isFPM,
 				Extensions: &builddef.VersionMap{
 					"intl":      "*",
@@ -133,7 +133,7 @@ func initSuccessfullyParseRawDefinitionWithStagesTC() newDefinitionTC {
 		expected: php.Definition{
 			BaseStage: php.Stage{
 				ExternalFiles:  []llbutils.ExternalFile{},
-				SystemPackages: map[string]string{},
+				SystemPackages: &builddef.VersionMap{},
 				FPM:            &isFPM,
 				Extensions: &builddef.VersionMap{
 					"intl":      "*",
@@ -283,7 +283,7 @@ func initSuccessfullyResolveDefaultDevStageTC(t *testing.T, mockCtrl *gomock.Con
 						Mode:        0644,
 					},
 				},
-				SystemPackages: map[string]string{},
+				SystemPackages: &builddef.VersionMap{},
 				FPM:            &isFPM,
 				Extensions: &builddef.VersionMap{
 					"intl":      "*",
@@ -341,7 +341,7 @@ func initSuccessfullyResolveWorkerStageTC(t *testing.T, mockCtrl *gomock.Control
 			},
 			Stage: php.Stage{
 				ExternalFiles: []llbutils.ExternalFile{},
-				SystemPackages: map[string]string{
+				SystemPackages: &builddef.VersionMap{
 					"zlib1g-dev":   "*",
 					"unzip":        "*",
 					"git":          "*",
@@ -418,7 +418,7 @@ func initRemoveDefaultExtensionsTC(t *testing.T, mockCtrl *gomock.Controller) re
 			PlatformReqs:   map[string]string{},
 			Stage: php.Stage{
 				ExternalFiles: []llbutils.ExternalFile{},
-				SystemPackages: map[string]string{
+				SystemPackages: &builddef.VersionMap{
 					"zlib1g-dev":    "*",
 					"unzip":         "*",
 					"git":           "*",
@@ -482,7 +482,7 @@ func initPreservePredefinedExtensionConstraintsTC(t *testing.T, mockCtrl *gomock
 			},
 			Stage: php.Stage{
 				ExternalFiles: []llbutils.ExternalFile{},
-				SystemPackages: map[string]string{
+				SystemPackages: &builddef.VersionMap{
 					"zlib1g-dev":   "*",
 					"unzip":        "*",
 					"git":          "*",
@@ -898,7 +898,7 @@ func TestMergeDefinition(t *testing.T) {
 				return php.Definition{
 					Webserver: &webserver.Definition{
 						ConfigFile:     &configFile,
-						SystemPackages: map[string]string{},
+						SystemPackages: &builddef.VersionMap{},
 					},
 					BaseStage: emptyStage(),
 					Stages:    php.DerivedStageSet{},
@@ -922,7 +922,7 @@ func TestMergeDefinition(t *testing.T) {
 				return php.Definition{
 					Webserver: &webserver.Definition{
 						ConfigFile:     &configFile,
-						SystemPackages: map[string]string{},
+						SystemPackages: &builddef.VersionMap{},
 					},
 					BaseStage: emptyStage(),
 					Stages:    php.DerivedStageSet{},
@@ -960,7 +960,7 @@ type mergeStageTC struct {
 func emptyStage() php.Stage {
 	return php.Stage{
 		ExternalFiles:  []llbutils.ExternalFile{},
-		SystemPackages: map[string]string{},
+		SystemPackages: &builddef.VersionMap{},
 		Extensions:     &builddef.VersionMap{},
 		GlobalDeps:     map[string]string{},
 		ConfigFiles:    php.PHPConfigFiles{},
@@ -1044,19 +1044,19 @@ func initMergeSystemPackagesWithBaseTC() mergeStageTC {
 	return mergeStageTC{
 		base: func() php.Stage {
 			return php.Stage{
-				SystemPackages: map[string]string{
+				SystemPackages: &builddef.VersionMap{
 					"curl": "*",
 				},
 			}
 		},
 		overriding: php.Stage{
-			SystemPackages: map[string]string{
+			SystemPackages: &builddef.VersionMap{
 				"chromium": "*",
 			},
 		},
 		expected: func() php.Stage {
 			s := emptyStage()
-			s.SystemPackages = map[string]string{
+			s.SystemPackages = &builddef.VersionMap{
 				"curl":     "*",
 				"chromium": "*",
 			}
@@ -1071,13 +1071,13 @@ func initMergeSystemPackagesWithoutBaseTC() mergeStageTC {
 			return php.Stage{}
 		},
 		overriding: php.Stage{
-			SystemPackages: map[string]string{
+			SystemPackages: &builddef.VersionMap{
 				"chromium": "*",
 			},
 		},
 		expected: func() php.Stage {
 			s := emptyStage()
-			s.SystemPackages = map[string]string{
+			s.SystemPackages = &builddef.VersionMap{
 				"chromium": "*",
 			}
 			return s

--- a/pkg/defkinds/php/locks.go
+++ b/pkg/defkinds/php/locks.go
@@ -147,19 +147,19 @@ func (h *PHPHandler) updateStagesLocks(
 	return locks, nil
 }
 
-func (h *PHPHandler) lockExtensions(extensions map[string]string) (map[string]string, error) {
+func (h *PHPHandler) lockExtensions(extensions *builddef.VersionMap) (map[string]string, error) {
 	resolved := map[string]string{}
 	ctx := context.Background()
 
 	// Remove extensions installed by default as this would result in a build
 	// error otherwise.
-	for _, name := range preinstalledExtensions {
-		if _, ok := extensions[name]; ok {
-			delete(extensions, name)
+	for _, name := range extensions.Names() {
+		if _, ok := preinstalledExtensions[name]; ok {
+			extensions.Remove(name)
 		}
 	}
 
-	for extName, constraint := range extensions {
+	for extName, constraint := range extensions.Map() {
 		if isCoreExtension(extName) {
 			resolved[extName] = constraint
 			continue

--- a/pkg/defkinds/php/locks.go
+++ b/pkg/defkinds/php/locks.go
@@ -129,7 +129,7 @@ func (h *PHPHandler) updateStagesLocks(
 		stageLocks := StageLocks{}
 		stageLocks.SystemPackages, err = pkgSolver.ResolveVersions(
 			defLocks.BaseImage,
-			stage.SystemPackages)
+			stage.SystemPackages.Map())
 		if err != nil {
 			return nil, xerrors.Errorf("could not resolve systems package versions: %w", err)
 		}

--- a/pkg/defkinds/php/testdata/debug-config/dump-dev.yml
+++ b/pkg/defkinds/php/testdata/debug-config/dump-dev.yml
@@ -19,7 +19,7 @@ stage:
   fpm: true
   command: null
   extensions:
-    apcu: =5.1.17
+    apcu: 5.1.17
     ctype: '*'
     date: '*'
     dom: '*'

--- a/pkg/defkinds/php/testdata/debug-config/dump-prod.yml
+++ b/pkg/defkinds/php/testdata/debug-config/dump-prod.yml
@@ -19,7 +19,7 @@ stage:
   fpm: true
   command: null
   extensions:
-    apcu: '*'
+    apcu: 5.1.17
     ctype: '*'
     date: '*'
     hash: '*'

--- a/pkg/defkinds/php/testdata/debug-config/zbuild.yml
+++ b/pkg/defkinds/php/testdata/debug-config/zbuild.yml
@@ -9,7 +9,7 @@ global_deps:
 extensions:
     # @TODO: wrong version of this ext is pinned for prod stage
     # @TODO: check why ext requirements from composer.json aren't in the lockfile
-    apcu: "=5.1.17"
+    apcu: "5.1.17"
     intl: "*"
     pdo_pgsql: "*"
 

--- a/pkg/defkinds/webserver/definition.go
+++ b/pkg/defkinds/webserver/definition.go
@@ -42,7 +42,7 @@ func NewKind(genericDef *builddef.BuildDef) (Definition, error) {
 	}
 
 	if def.Healthcheck != nil && *def.Healthcheck {
-		def.SystemPackages.Add("curl", "*", false)
+		def.SystemPackages.Add("curl", "*")
 	}
 
 	return def, def.Validate()

--- a/pkg/defkinds/webserver/definition_test.go
+++ b/pkg/defkinds/webserver/definition_test.go
@@ -27,7 +27,7 @@ func initSuccessfullyParseRawDefinitionTC() newDefinitionTC {
 			Type:        "nginx",
 			ConfigFile:  &configFile,
 			Healthcheck: &healthcheck,
-			SystemPackages: map[string]string{
+			SystemPackages: &builddef.VersionMap{
 				"curl": "*",
 			},
 			Assets: []webserver.AssetToCopy{
@@ -126,7 +126,7 @@ func TestDefinitionMerge(t *testing.T) {
 			expected: func() webserver.Definition {
 				return webserver.Definition{
 					Type:           webserver.WebserverType("caddy"),
-					SystemPackages: map[string]string{},
+					SystemPackages: &builddef.VersionMap{},
 				}
 			},
 		},
@@ -142,21 +142,21 @@ func TestDefinitionMerge(t *testing.T) {
 			expected: func() webserver.Definition {
 				return webserver.Definition{
 					Type:           webserver.WebserverType("caddy"),
-					SystemPackages: map[string]string{},
+					SystemPackages: &builddef.VersionMap{},
 				}
 			},
 		},
 		"merge system packages with base": {
 			base: func() webserver.Definition {
 				return webserver.Definition{
-					SystemPackages: map[string]string{
+					SystemPackages: &builddef.VersionMap{
 						"curl": "*",
 					},
 				}
 			},
 			overriding: func() webserver.Definition {
 				return webserver.Definition{
-					SystemPackages: map[string]string{
+					SystemPackages: &builddef.VersionMap{
 						"curl":            "7.64.0-4",
 						"ca-certificates": "*",
 					},
@@ -164,7 +164,7 @@ func TestDefinitionMerge(t *testing.T) {
 			},
 			expected: func() webserver.Definition {
 				return webserver.Definition{
-					SystemPackages: map[string]string{
+					SystemPackages: &builddef.VersionMap{
 						"curl":            "7.64.0-4",
 						"ca-certificates": "*",
 					},
@@ -177,7 +177,7 @@ func TestDefinitionMerge(t *testing.T) {
 			},
 			overriding: func() webserver.Definition {
 				return webserver.Definition{
-					SystemPackages: map[string]string{
+					SystemPackages: &builddef.VersionMap{
 						"curl":            "7.64.0-4",
 						"ca-certificates": "*",
 					},
@@ -185,7 +185,7 @@ func TestDefinitionMerge(t *testing.T) {
 			},
 			expected: func() webserver.Definition {
 				return webserver.Definition{
-					SystemPackages: map[string]string{
+					SystemPackages: &builddef.VersionMap{
 						"curl":            "7.64.0-4",
 						"ca-certificates": "*",
 					},
@@ -209,7 +209,7 @@ func TestDefinitionMerge(t *testing.T) {
 				configFile := "docker/nginx.conf"
 				return webserver.Definition{
 					ConfigFile:     &configFile,
-					SystemPackages: map[string]string{},
+					SystemPackages: &builddef.VersionMap{},
 				}
 			},
 		},
@@ -227,7 +227,7 @@ func TestDefinitionMerge(t *testing.T) {
 				configFile := "docker/nginx.conf"
 				return webserver.Definition{
 					ConfigFile:     &configFile,
-					SystemPackages: map[string]string{},
+					SystemPackages: &builddef.VersionMap{},
 				}
 			},
 		},
@@ -245,7 +245,7 @@ func TestDefinitionMerge(t *testing.T) {
 				configFile := "nginx.conf"
 				return webserver.Definition{
 					ConfigFile:     &configFile,
-					SystemPackages: map[string]string{},
+					SystemPackages: &builddef.VersionMap{},
 				}
 			},
 		},
@@ -266,7 +266,7 @@ func TestDefinitionMerge(t *testing.T) {
 				healthcheck := false
 				return webserver.Definition{
 					Healthcheck:    &healthcheck,
-					SystemPackages: map[string]string{},
+					SystemPackages: &builddef.VersionMap{},
 				}
 			},
 		},
@@ -284,7 +284,7 @@ func TestDefinitionMerge(t *testing.T) {
 				healthcheck := true
 				return webserver.Definition{
 					Healthcheck:    &healthcheck,
-					SystemPackages: map[string]string{},
+					SystemPackages: &builddef.VersionMap{},
 				}
 			},
 		},
@@ -302,7 +302,7 @@ func TestDefinitionMerge(t *testing.T) {
 				healthcheck := true
 				return webserver.Definition{
 					Healthcheck:    &healthcheck,
-					SystemPackages: map[string]string{},
+					SystemPackages: &builddef.VersionMap{},
 				}
 			},
 		},
@@ -327,7 +327,7 @@ func TestDefinitionMerge(t *testing.T) {
 						{From: "public/", To: "public/"},
 						{From: "web/", To: "web/"},
 					},
-					SystemPackages: map[string]string{},
+					SystemPackages: &builddef.VersionMap{},
 				}
 			},
 		},
@@ -347,7 +347,7 @@ func TestDefinitionMerge(t *testing.T) {
 					Assets: []webserver.AssetToCopy{
 						{From: "web/", To: "web/"},
 					},
-					SystemPackages: map[string]string{},
+					SystemPackages: &builddef.VersionMap{},
 				}
 			},
 		},

--- a/pkg/defkinds/webserver/locks.go
+++ b/pkg/defkinds/webserver/locks.go
@@ -45,7 +45,7 @@ func (h *WebserverHandler) UpdateLocks(
 
 	def.Locks.SystemPackages, err = pkgSolver.ResolveVersions(
 		def.Locks.BaseImage,
-		def.SystemPackages)
+		def.SystemPackages.Map())
 	if err != nil {
 		return nil, xerrors.Errorf("could not resolve system packages: %w", err)
 	}


### PR DESCRIPTION
This new struct is used in specialized definitions whenever a map of packages/extensions/etc... has to be associated with version constraints. This struct has an `Add()` method which is used to define values without overwriting manually-defined ones. This was originally motivated by a bug in the php handler but this struct seems useful in other places.

Here's the original bug description:

> The infered extensions were overwriting manually defined version
constraints. Because of that, PHP prod stages were always resolving the
latest version of APCu, even when a specific version was pinned in the
zbuildfile.
>
> This new struct is used to properly add infered extensions without
overwriting manually defined version constraints.

Supersedes #20.