### PR TITLE
Add tools to help review changes on LLB DAGs dumps

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,21 @@ $ docker build -f zbuild.yml -t prod .
 
 ```bash
 $ zbuild debug-llb --target prod | buildctl debug dump-llb
+# Or
+$ zbuild debug-llb --target prod --json | zbuild llbgraph | dot /dev/stdin -o /dev/stdout -T png | feh -
+```
+
+#### Review LLB DAGs changes
+
+```bash
+# Visually review differences between two LLB DAGs
+$ ./tools/diff-dotgraph.py "$(cat graph1)" "$(cat graph2)"
+# Visually review unstaged changes
+$ ./tools/diff-dumps-from-git.py
+# Visually review changes from a commit range
+$ ./tools/diff-dumps-from-git.py HEAD~10:HEAD~1
+# Visually review a bunch of graphs from a commit range
+$ ./tools/diff-dumps-from-git.py HEAD~10:HEAD~1 path/to/graph1 path/to/graph2
 ```
 
 #### Run with buildkitd

--- a/tools/diff-dotgraph.py
+++ b/tools/diff-dotgraph.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python
+import pydot
+import sys
+from typing import Dict, List
+
+
+def usage():
+    usage_text = """Usage: {0} "$(cat graph1)" "$(cat graph2)"
+
+This tool takes two graphs and finds all the nodes in the second graph that
+don't exist in the first graph. All these nodes are then colored in grey and
+the final graph is printed back.
+
+Example: {0} \\
+    "$(git show HEAD^:pkg/defkinds/webserver/testdata/build/from-git-context.json | zbuild llbgraph)" \\
+    "$(cat pkg/defkinds/webserver/testdata/build/from-git-context.json | zbuild llbgraph)" \\
+    | dot /dev/stdin -o /dev/stdout -T png | feh - """
+    
+    print(usage_text.format(sys.argv[0]), file=sys.stderr)
+
+
+def list_edges(graph: pydot.Graph) -> Dict[str, str]:
+    # Source node is stored as key, dest node as value
+    edges = {}
+
+    for edge in graph.get_edge_list():
+        edges[edge.get_source()] = edge.get_destination()
+    
+    return edges
+
+
+def find_children_nodes(graph: pydot.Graph, traversed: List[str], node_name: str) -> List[str]:
+    children = []
+
+    for edge in graph.get_edge(node_name):
+        dest = edge.get_destination()
+        if dest not in traversed:
+            children.append(dest)
+    
+    return children
+
+
+def color_nodes(graph: pydot.Graph, nodes: List[str]):
+    for node_name in nodes:
+        node = graph.get_node(node_name)[0]
+        node.set_fillcolor("#5f5f5f5f")
+        node.set_style("filled")
+
+
+def diff_graphs(origin_graph: pydot.Graph, updated_graph: pydot.Graph):
+    origin_edges = list_edges(origin_graph)
+    traversed = []
+
+    for node in updated_graph.get_nodes():
+        if node in traversed:
+            continue
+
+        node_name = node.get_name()
+        children = find_children_nodes(updated_graph, traversed, node_name)
+        to_color = [node_name] + children
+        traversed += to_color
+
+        if node_name in origin_edges:
+            continue
+
+        color_nodes(updated_graph, to_color)
+    
+    print(updated_graph.to_string())
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 3:
+        usage()
+        sys.exit(1)
+
+    origin = pydot.graph_from_dot_data(sys.argv[1])[0]
+    updated = pydot.graph_from_dot_data(sys.argv[2])[0]
+
+    diff_graphs(origin, updated)

--- a/tools/diff-dumps-from-git.py
+++ b/tools/diff-dumps-from-git.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python
+import pprint
+import subprocess
+import sys
+from typing import List
+
+
+def usage():
+    usage_text = """Usage: {0} <commit-range> [<path> ...]
+
+Warning: This tool relies on dot and feh to generate and open the colored graph.
+
+Parameters:
+    * <commit-range> is either "unstaged" or <first-commit>[:<last-commit>]
+      with <commit-range> defaulting to "unstaged" and <last-commit> defaulting
+      to HEAD. When "unstaged" is specified, the tool will comapre the unstaged
+      version with the last commit.
+    * <path> can be specified multiple times but this will open as many times feh.
+    * When <path> is not specified, the tool finds all the JSON dumps updated 
+      in the commit range.""".format(sys.argv[0])
+
+    print(usage_text, file=sys.stderr)
+
+
+def find_updated_dumps(first: str, last: str):
+    cmd = "git diff --name-only {first} "
+    if last != "unstaged":
+        cmd += "{last} "
+    
+    cmd = (cmd + "| egrep '*.json'").format(first=first, last=last)
+
+    res = subprocess.run(cmd, shell=True, check=True, stdout=subprocess.PIPE, text=True)
+    dumps = str(res.stdout).split("\n")
+
+    return [dump.strip() for dump in dumps if dump != ""]
+
+
+def diff_path(first: str, last: str, path: str):
+    args = {"tool": "./tools/diff-dotgraph.py",
+            "first": first,
+            "last": last,
+            "path": path.strip()}
+    
+    cmd = """{tool} "$(git show {first}:{path} | zbuild llbgraph)" """.format(**args)
+    if last != "unstaged":
+        cmd += "\"$(git show {last}:{path} | zbuild llbgraph)\""
+    else:
+        cmd += "\"$(cat {path} | zbuild llbgraph)\" "
+    
+    cmd += "| dot /dev/stdin -o /dev/stdout -T png | feh -"
+    cmd = cmd.format(**args)
+    subprocess.run(cmd, shell=True, check=True)
+
+
+def diff_commit_range(commit_range: str, paths: List[str]):
+    commits = commit_range.split(":")
+    if len(commits) > 2:
+        print("ERROR: Invalid commit range.\n", file=sys.stderr)
+        usage()
+        sys.exit(1)
+    if commits[0] == "unstaged":
+        commits = ["HEAD", "unstaged"]
+    if len(commits) == 1:
+        commits.append("HEAD")
+
+    if len(paths) == 0:
+        paths = find_updated_dumps(commits[0], commits[1])
+
+    for path in paths:
+        diff_path(commits[0], commits[1], path)
+
+
+if __name__ == "__main__":
+    if len(sys.argv) == 2 and sys.argv[1] == "--help":
+        usage()
+        sys.exit(0)
+
+    commit_range = sys.argv[1] if len(sys.argv) >= 2 else "unstaged"
+    paths = sys.argv[2:] if len(sys.argv) >= 3 else []
+    
+    diff_commit_range(commit_range, paths)


### PR DESCRIPTION
This commit adds two new tools. The first one takes two graphs, compare
them and color in grey all the nodes that aren't in both graphs.

The second tool use the first one to open up a colored graph for every
dumps that changed in a commit range (or unstaged dumps if no range is
provided).

Related to: https://kantree.io/share/8ec2e24b-9dfa-494d-bc2b-1245b1c57a73