### PR TITLE
Support a second build context dedicated to config files

### DIFF
--- a/pkg/builddef/build_opts.go
+++ b/pkg/builddef/build_opts.go
@@ -10,23 +10,25 @@ import (
 // BuildOpts represents the parameters passed to specialized builders.
 // (see github.com/NiR-/zbuild/pkg/defkinds/)
 type BuildOpts struct {
-	Def       *BuildDef
-	Source    *llb.State
-	SessionID string
+	Def         *BuildDef
+	SourceState *llb.State
+	SessionID   string
 	// LocalUniqueID is useful mostly for test purpose, in order to use
 	// a predefine value and have stable op digests.
 	LocalUniqueID string
 	File          string
 	LockFile      string
 	Stage         string
-	ContextName   string
+	SourceContext string
+	ConfigContext string
 }
 
 func NewBuildOpts(file string) BuildOpts {
 	return BuildOpts{
-		File:        file,
-		LockFile:    LockFilepath(file),
-		ContextName: "context",
+		File:          file,
+		LockFile:      LockFilepath(file),
+		SourceContext: "context",
+		ConfigContext: "context",
 	}
 }
 

--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -24,6 +24,7 @@ import (
 const (
 	keyTarget        = "target"
 	keyContext       = "context"
+	keyConfigContext = "config-context"
 	keyDockerContext = "contextkey"
 	keyFilename      = "filename"
 )
@@ -65,17 +66,23 @@ func buildOptsFromBuildkitOpts(c client.Client) builddef.BuildOpts {
 		stage = v
 	}
 
-	contextName := "context"
+	sourceContext := "context"
 	if v, ok := opts[keyDockerContext]; ok {
-		contextName = v
+		sourceContext = v
 	} else if v, ok := opts[keyContext]; ok {
-		contextName = v
+		sourceContext = v
+	}
+
+	configContext := sourceContext
+	if v, ok := opts["build-arg:"+keyConfigContext]; ok {
+		configContext = v
 	}
 
 	buildOpts := builddef.NewBuildOpts(file)
 	buildOpts.Stage = stage
 	buildOpts.SessionID = sessionID
-	buildOpts.ContextName = contextName
+	buildOpts.SourceContext = sourceContext
+	buildOpts.ConfigContext = configContext
 
 	return buildOpts
 }
@@ -122,7 +129,7 @@ func (b Builder) build(
 
 	if webserverStage {
 		buildOpts.Def = newBuildDefForWebserver(buildOpts.Def)
-		buildOpts.Source = &state
+		buildOpts.SourceState = &state
 		buildOpts.Stage = "webserver"
 
 		return b.build(ctx, solver, buildOpts)

--- a/pkg/defkinds/nodejs/builder.go
+++ b/pkg/defkinds/nodejs/builder.go
@@ -182,7 +182,7 @@ func (h *NodeJSHandler) yarnInstall(
 	state llb.State,
 	buildOpts builddef.BuildOpts,
 ) llb.State {
-	packageSrc := llb.Local(buildOpts.ContextName,
+	packageSrc := llb.Local(buildOpts.ConfigContext,
 		llb.IncludePatterns([]string{"package.json", "yarn.lock"}),
 		llb.LocalUniqueID(buildOpts.LocalUniqueID),
 		llb.SessionID(buildOpts.SessionID),
@@ -205,7 +205,7 @@ func (h *NodeJSHandler) copySources(
 	state llb.State,
 	buildOpts builddef.BuildOpts,
 ) llb.State {
-	buildContextSrc := llb.Local(buildOpts.ContextName,
+	buildContextSrc := llb.Local(buildOpts.SourceContext,
 		llb.IncludePatterns(includePatterns(stageDef)),
 		llb.ExcludePatterns(excludePatterns(stageDef)),
 		llb.LocalUniqueID(buildOpts.LocalUniqueID),

--- a/pkg/defkinds/nodejs/builder_test.go
+++ b/pkg/defkinds/nodejs/builder_test.go
@@ -41,7 +41,8 @@ func initBuildLLBForDevStageTC(t *testing.T, mockCtrl *gomock.Controller) buildT
 			Stage:         "dev",
 			SessionID:     "<SESSION-ID>",
 			LocalUniqueID: "x1htr02606a9rk8b0daewh9es",
-			ContextName:   "context",
+			SourceContext: "context",
+			ConfigContext: "context",
 		},
 		expectedState: "testdata/build/state-dev.json",
 		expectedImage: &image.Image{
@@ -88,7 +89,8 @@ func initBuildLLBForWorkerStageTC(t *testing.T, mockCtrl *gomock.Controller) bui
 			Stage:         "worker",
 			SessionID:     "<SESSION-ID>",
 			LocalUniqueID: "x1htr02606a9rk8b0daewh9es",
-			ContextName:   "context",
+			SourceContext: "context",
+			ConfigContext: "context",
 		},
 		expectedState: "testdata/build/state-worker.json",
 		expectedImage: &image.Image{

--- a/pkg/defkinds/php/builder.go
+++ b/pkg/defkinds/php/builder.go
@@ -150,7 +150,7 @@ func copyConfigFiles(
 		configFiles = append(configFiles, *stage.ConfigFiles.FPMConfigFile)
 	}
 
-	configFilesSrc := llbutils.BuildContext(buildOpts.ContextName,
+	configFilesSrc := llbutils.BuildContext(buildOpts.ConfigContext,
 		llb.IncludePatterns(configFiles),
 		llb.LocalUniqueID(buildOpts.LocalUniqueID),
 		llb.SessionID(buildOpts.SessionID),
@@ -182,7 +182,7 @@ func copySourceFiles(
 	state llb.State,
 	buildOpts builddef.BuildOpts,
 ) llb.State {
-	buildContextSrc := llbutils.BuildContext(buildOpts.ContextName,
+	buildContextSrc := llbutils.BuildContext(buildOpts.SourceContext,
 		llb.IncludePatterns(includePatterns(&stage)),
 		llb.ExcludePatterns(excludePatterns(&stage)),
 		llb.LocalUniqueID(buildOpts.LocalUniqueID),
@@ -279,7 +279,7 @@ func composerInstall(
 	state llb.State,
 	buildOpts builddef.BuildOpts,
 ) llb.State {
-	composerSrc := llbutils.BuildContext(buildOpts.ContextName,
+	composerSrc := llbutils.BuildContext(buildOpts.SourceContext,
 		llb.IncludePatterns([]string{"composer.json", "composer.lock"}),
 		llb.LocalUniqueID(buildOpts.LocalUniqueID),
 		llb.SessionID(buildOpts.SessionID),

--- a/pkg/defkinds/php/builder_test.go
+++ b/pkg/defkinds/php/builder_test.go
@@ -50,7 +50,8 @@ func initBuildLLBForDevStageTC(t *testing.T, mockCtrl *gomock.Controller) buildT
 			Stage:         "dev",
 			SessionID:     "<SESSION-ID>",
 			LocalUniqueID: "x1htr02606a9rk8b0daewh9es",
-			ContextName:   "context",
+			SourceContext: "context",
+			ConfigContext: "context",
 		},
 		expectedState: "testdata/build/state-dev.json",
 		expectedImage: &image.Image{
@@ -110,7 +111,8 @@ func initBuildLLBForProdStageTC(t *testing.T, mockCtrl *gomock.Controller) build
 			Stage:         "prod",
 			SessionID:     "<SESSION-ID>",
 			LocalUniqueID: "x1htr02606a9rk8b0daewh9es",
-			ContextName:   "context",
+			SourceContext: "context",
+			ConfigContext: "context",
 		},
 		expectedState: "testdata/build/state-prod.json",
 		expectedImage: &image.Image{
@@ -176,7 +178,8 @@ func initBuildProdStageFromGitBasedBuildContextTC(t *testing.T, mockCtrl *gomock
 			Stage:         "prod",
 			SessionID:     "<SESSION-ID>",
 			LocalUniqueID: "x1htr02606a9rk8b0daewh9es",
-			ContextName:   "git://github.com/some/repo",
+			SourceContext: "git://github.com/some/repo",
+			ConfigContext: "git://github.com/some/repo",
 		},
 		expectedState: "testdata/build/from-git-context.json",
 		expectedImage: &image.Image{

--- a/pkg/defkinds/webserver/builder.go
+++ b/pkg/defkinds/webserver/builder.go
@@ -59,7 +59,7 @@ func (h *WebserverHandler) Build(
 	img = image.CloneMeta(baseImg)
 	img.Config.Labels[builddef.ZbuildLabel] = "true"
 
-	if buildOpts.Source == nil && len(def.Assets) > 0 {
+	if buildOpts.SourceState == nil && len(def.Assets) > 0 {
 		return state, img, xerrors.New("no source state to copy assets from has been provided")
 	}
 
@@ -70,7 +70,7 @@ func (h *WebserverHandler) Build(
 	}
 
 	for _, asset := range def.Assets {
-		state = llbutils.Copy(*buildOpts.Source, asset.From, state, asset.To, fileOwner)
+		state = llbutils.Copy(*buildOpts.SourceState, asset.From, state, asset.To, fileOwner)
 	}
 
 	setImageMetadata(def, state, img)
@@ -83,7 +83,7 @@ func (h *WebserverHandler) copyConfigFile(
 	def Definition,
 	buildOpts builddef.BuildOpts,
 ) llb.State {
-	configFileSrc := llbutils.BuildContext(buildOpts.ContextName,
+	configFileSrc := llbutils.BuildContext(buildOpts.ConfigContext,
 		llb.IncludePatterns([]string{*def.ConfigFile}),
 		llb.LocalUniqueID(buildOpts.LocalUniqueID),
 		llb.SessionID(buildOpts.SessionID),

--- a/pkg/defkinds/webserver/builder_test.go
+++ b/pkg/defkinds/webserver/builder_test.go
@@ -46,7 +46,8 @@ func initBuildLLBTC(t *testing.T, mockCtrl *gomock.Controller) buildTC {
 			Stage:         "",
 			SessionID:     "<SESSION-ID>",
 			LocalUniqueID: "x1htr02606a9rk8b0daewh9es",
-			ContextName:   "context",
+			SourceContext: "context",
+			ConfigContext: "context",
 		},
 		expectedState: "testdata/build/state.json",
 		expectedImage: &image.Image{
@@ -105,7 +106,8 @@ func initBuildLLBFromGitContextTC(t *testing.T, mockCtrl *gomock.Controller) bui
 			Stage:         "",
 			SessionID:     "<SESSION-ID>",
 			LocalUniqueID: "x1htr02606a9rk8b0daewh9es",
-			ContextName:   "git://github.com/some/repo",
+			SourceContext: "git://github.com/some/repo",
+			ConfigContext: "git://github.com/some/repo",
 		},
 		expectedState: "testdata/build/from-git-context.json",
 		expectedImage: &image.Image{
@@ -164,8 +166,9 @@ func initFailToBuildWithAssetsWhenNoSourceInTheBuildOptsTC(t *testing.T, mockCtr
 			Stage:         "",
 			SessionID:     "<SESSION-ID>",
 			LocalUniqueID: "x1htr02606a9rk8b0daewh9es",
-			ContextName:   "context",
-			Source:        nil,
+			SourceContext: "context",
+			ConfigContext: "context",
+			SourceState:   nil,
 		},
 		expectedErr: xerrors.New("no source state to copy assets from has been provided"),
 	}


### PR DESCRIPTION
Until now, zbuild supported a single build context like Docker and
Dockerfiles. However zbuild now supports separate source and config
contexts. The former is used to copy source files (e.g. composer.*,
packages.json, yarn.lock, source dirs, etc...) whereas the latter
context is used to copy config files (e.g. fpm.conf, nginx.conf,
etc...). This is mostly useful for building custom images for FOSS
projects with custom config files.