### PR TITLE
Add Alpine support to NodeJS definitions

### DIFF
--- a/examples/api-platform-demo/admin/zbuild.lock
+++ b/examples/api-platform-demo/admin/zbuild.lock
@@ -1,4 +1,8 @@
-base: docker.io/library/node:12-buster-slim@sha256:4d1016eefc4e6dc52ba9be6550dcb25a6e1826117507e65eda3650d6eb19f042
+base: docker.io/library/node:12-alpine@sha256:1dd4309479f031295f3dfb61cf3afc3efeb1a991b012e105d1a95efc038b72f6
+osrelease:
+  name: alpine
+  versionname: ""
+  versionid: 3.11.3
 source_context:
   path: admin
   reference: 5ecd2177087afbcce8f88ddfedbc7b95e738d961
@@ -10,6 +14,6 @@ stages:
   prod:
     system_packages: {}
 webserver:
-  base_image: docker.io/library/nginx:latest@sha256:70821e443be75ea38bdf52a974fd2271babd5875b2b1964f05025981c75a6717
+  base_image: docker.io/library/nginx:latest@sha256:ad5552c786f128e389a0263104ae39f3d3c7895579d45ae716f528185b36bc6f
   system_packages:
     curl: 7.64.0-4

--- a/examples/api-platform-demo/admin/zbuild.yml
+++ b/examples/api-platform-demo/admin/zbuild.yml
@@ -1,16 +1,19 @@
-# syntax=akerouanton/zbuilder:200126-30
+# syntax=akerouanton/zbuilder:200208-04
 kind: nodejs
 version: 12
-# @TODO: uncomment once alpine support has been added
-#alpine: true
+alpine: true
+
+frontend: true
+build_command: yarn build
 
 source_context:
   type: git
   source: github.com/api-platform/demo
   path: admin
 
-frontend: true
-build_command: yarn build
+sources:
+  - src/
+  - public/
 
 config_files:
   .env.production: .env

--- a/examples/api-platform-demo/api/zbuild.lock
+++ b/examples/api-platform-demo/api/zbuild.lock
@@ -1,5 +1,9 @@
-base_image: docker.io/library/php:7.3-fpm-buster@sha256:851a0eba027503c335b832a5925ed245433903245c76fbe75e3dd17572d0db28
+base_image: docker.io/library/php:7.3-fpm-alpine@sha256:c66cb88c90252cfe74491ec5685faf39672ea759aea16a86500242e71c0ce1a7
 extension_dir: /usr/local/lib/php/extensions/no-debug-non-zts-20180731
+osrelease:
+  name: alpine
+  versionname: ""
+  versionid: 3.11.3
 source_context:
   path: api
   reference: 5ecd2177087afbcce8f88ddfedbc7b95e738d961
@@ -14,26 +18,24 @@ stages:
       pdo_pgsql: '*'
       zip: '*'
     system_packages:
-      git: 1:2.20.1-2+deb10u1
-      libicu-dev: 63.1-6
-      libpq-dev: 11.5-1+deb10u1
-      libxml2-dev: 2.9.4+dfsg1-7+b3
-      libzip-dev: 1.5.1-4
-      unzip: 6.0-23+deb10u1
-      zlib1g-dev: 1:1.2.11.dfsg-1
+      git: 2.24.1-r0
+      icu-dev: 64.2-r0
+      libxml2-dev: 2.9.10-r1
+      libzip-dev: 1.5.2-r0
+      postgresql-dev: 12.1-r0
+      unzip: 6.0-r4
   dev:
     extensions:
       intl: '*'
       pdo_pgsql: '*'
       zip: '*'
     system_packages:
-      git: 1:2.20.1-2+deb10u1
-      libicu-dev: 63.1-6
-      libpq-dev: 11.5-1+deb10u1
-      libxml2-dev: 2.9.4+dfsg1-7+b3
-      libzip-dev: 1.5.1-4
-      unzip: 6.0-23+deb10u1
-      zlib1g-dev: 1:1.2.11.dfsg-1
+      git: 2.24.1-r0
+      icu-dev: 64.2-r0
+      libxml2-dev: 2.9.10-r1
+      libzip-dev: 1.5.2-r0
+      postgresql-dev: 12.1-r0
+      unzip: 6.0-r4
   prod:
     extensions:
       apcu: 5.1.17
@@ -42,14 +44,13 @@ stages:
       pdo_pgsql: '*'
       zip: '*'
     system_packages:
-      git: 1:2.20.1-2+deb10u1
-      libicu-dev: 63.1-6
-      libpq-dev: 11.5-1+deb10u1
-      libxml2-dev: 2.9.4+dfsg1-7+b3
-      libzip-dev: 1.5.1-4
-      unzip: 6.0-23+deb10u1
-      zlib1g-dev: 1:1.2.11.dfsg-1
+      git: 2.24.1-r0
+      icu-dev: 64.2-r0
+      libxml2-dev: 2.9.10-r1
+      libzip-dev: 1.5.2-r0
+      postgresql-dev: 12.1-r0
+      unzip: 6.0-r4
 webserver:
-  base_image: docker.io/library/nginx:latest@sha256:70821e443be75ea38bdf52a974fd2271babd5875b2b1964f05025981c75a6717
+  base_image: docker.io/library/nginx:latest@sha256:ad5552c786f128e389a0263104ae39f3d3c7895579d45ae716f528185b36bc6f
   system_packages:
     curl: 7.64.0-4

--- a/examples/api-platform-demo/api/zbuild.yml
+++ b/examples/api-platform-demo/api/zbuild.yml
@@ -1,6 +1,7 @@
-# syntax=akerouanton/zbuilder:200126-30
+# syntax=akerouanton/zbuilder:200203-01
 kind: php
 version: 7.3
+alpine: true
 # @TODO: check base + version
 # base: php:7.3-fpm-buster
 # base: php@sha256:db5bce28b6eabd8bd963cfd95131a01171acea9cff500447bb8d9e05afd34e4b

--- a/examples/api-platform-demo/client/zbuild.lock
+++ b/examples/api-platform-demo/client/zbuild.lock
@@ -1,4 +1,8 @@
-base: docker.io/library/node:12-buster-slim@sha256:4d1016eefc4e6dc52ba9be6550dcb25a6e1826117507e65eda3650d6eb19f042
+base: docker.io/library/node:12-alpine@sha256:1dd4309479f031295f3dfb61cf3afc3efeb1a991b012e105d1a95efc038b72f6
+osrelease:
+  name: alpine
+  versionname: ""
+  versionid: 3.11.3
 source_context:
   path: client
   reference: 5ecd2177087afbcce8f88ddfedbc7b95e738d961
@@ -10,6 +14,6 @@ stages:
   prod:
     system_packages: {}
 webserver:
-  base_image: docker.io/library/nginx:latest@sha256:70821e443be75ea38bdf52a974fd2271babd5875b2b1964f05025981c75a6717
+  base_image: docker.io/library/nginx:latest@sha256:ad5552c786f128e389a0263104ae39f3d3c7895579d45ae716f528185b36bc6f
   system_packages:
     curl: 7.64.0-4

--- a/examples/api-platform-demo/client/zbuild.yml
+++ b/examples/api-platform-demo/client/zbuild.yml
@@ -1,6 +1,7 @@
-# syntax=akerouanton/zbuilder:200126-30
+# syntax=akerouanton/zbuilder:200208-04
 kind: nodejs
 version: 12
+alpine: true
 
 frontend: true
 build_command: yarn build

--- a/examples/symfony-demo/docker-compose.yml
+++ b/examples/symfony-demo/docker-compose.yml
@@ -17,5 +17,6 @@ services:
       dockerfile: zbuild.yml
       context: .
       target: webserver-prod
+    restart: on-failure
     ports:
       - "80:80"

--- a/pkg/defkinds/nodejs/definition.go
+++ b/pkg/defkinds/nodejs/definition.go
@@ -151,10 +151,19 @@ func NewKind(genericDef *builddef.BuildDef) (Definition, error) {
 	}
 
 	if def.BaseImage == "" {
-		def.BaseImage = fmt.Sprintf("docker.io/library/node:%s-buster-slim", def.Version)
+		def.BaseImage = defaultBaseImage(def)
 	}
 
 	return def, nil
+}
+
+func defaultBaseImage(def Definition) string {
+	flavor := "buster-slim"
+	if def.Alpine {
+		flavor = "alpine"
+	}
+
+	return fmt.Sprintf("docker.io/library/node:%s-%s", def.Version, flavor)
 }
 
 type Definition struct {
@@ -162,6 +171,7 @@ type Definition struct {
 
 	BaseImage string          `mapstructure:"base"`
 	Version   string          `mapstructure:"version"`
+	Alpine    bool            `mapstructure:"alpine"`
 	Stages    DerivedStageSet `mapstructure:"stages"`
 	// @TODO: move to Stage?
 	IsFrontend bool `mapstructure:"frontend"`
@@ -196,6 +206,7 @@ func (d Definition) Copy() Definition {
 		BaseStage:     d.BaseStage.Copy(),
 		BaseImage:     d.BaseImage,
 		Version:       d.Version,
+		Alpine:        d.Alpine,
 		Stages:        d.Stages.Copy(),
 		IsFrontend:    d.IsFrontend,
 		SourceContext: d.SourceContext.Copy(),
@@ -211,6 +222,7 @@ func (base Definition) Merge(overriding Definition) Definition {
 	new.Stages = new.Stages.Merge(overriding.Stages)
 	new.BaseImage = overriding.BaseImage
 	new.Version = overriding.Version
+	new.Alpine = overriding.Alpine
 	new.IsFrontend = overriding.IsFrontend
 	new.SourceContext = overriding.SourceContext.Copy()
 

--- a/pkg/defkinds/nodejs/definition_test.go
+++ b/pkg/defkinds/nodejs/definition_test.go
@@ -1227,6 +1227,44 @@ func initMergeIsFrontendWithoutBaseTC() mergeDefinitionTC {
 	}
 }
 
+func initMergeAlpineWithBaseTC() mergeDefinitionTC {
+	return mergeDefinitionTC{
+		base: func() nodejs.Definition {
+			return nodejs.Definition{
+				Alpine: true,
+			}
+		},
+		overriding: nodejs.Definition{
+			Alpine: false,
+		},
+		expected: func() nodejs.Definition {
+			return nodejs.Definition{
+				Alpine:    false,
+				BaseStage: emptyStage(),
+				Stages:    nodejs.DerivedStageSet{},
+			}
+		},
+	}
+}
+
+func initMergeAlpineWithoutBaseTC() mergeDefinitionTC {
+	return mergeDefinitionTC{
+		base: func() nodejs.Definition {
+			return nodejs.Definition{}
+		},
+		overriding: nodejs.Definition{
+			Alpine: true,
+		},
+		expected: func() nodejs.Definition {
+			return nodejs.Definition{
+				Alpine:    true,
+				BaseStage: emptyStage(),
+				Stages:    nodejs.DerivedStageSet{},
+			}
+		},
+	}
+}
+
 func TestDefinitionMerge(t *testing.T) {
 	testcases := map[string]func() mergeDefinitionTC{
 		"merge base stage with base":     initMergeBaseStageWithBaseTC,
@@ -1239,6 +1277,8 @@ func TestDefinitionMerge(t *testing.T) {
 		"merge stages without base":      initMergeStagesWithoutBaseTC,
 		"merge is frontend with base":    initMergeIsFrontendWithBaseTC,
 		"merge is frontend without base": initMergeIsFrontendWithoutBaseTC,
+		"merge alpine with base":         initMergeAlpineWithBaseTC,
+		"merge alpine without base":      initMergeAlpineWithoutBaseTC,
 	}
 
 	for tcname := range testcases {

--- a/pkg/defkinds/nodejs/testdata/build/alpine.lock
+++ b/pkg/defkinds/nodejs/testdata/build/alpine.lock
@@ -1,0 +1,17 @@
+base: docker.io/library/node:12-alpine@sha256:1dd4309479f031295f3dfb61cf3afc3efeb1a991b012e105d1a95efc038b72f6
+osrelease:
+  name: alpine
+  versionname: ""
+  versionid: 3.11.3
+source_context: null
+stages:
+  dev:
+    system_packages:
+      libsass-dev: 3.6.3-r1
+  prod:
+    system_packages:
+      libsass-dev: 3.6.3-r1
+webserver:
+  base_image: docker.io/library/nginx:latest@sha256:ad5552c786f128e389a0263104ae39f3d3c7895579d45ae716f528185b36bc6f
+  system_packages:
+    curl: 7.64.0-4

--- a/pkg/defkinds/nodejs/testdata/build/alpine.yml
+++ b/pkg/defkinds/nodejs/testdata/build/alpine.yml
@@ -2,5 +2,7 @@ kind: nodejs
 version: 12
 alpine: true
 
+frontend: true
+
 system_packages:
   libsass-dev: "*"

--- a/pkg/defkinds/nodejs/testdata/build/state-alpine-prod.json
+++ b/pkg/defkinds/nodejs/testdata/build/state-alpine-prod.json
@@ -1,0 +1,450 @@
+[
+  {
+    "RawOp": "CkkKR3NoYTI1Njo5ODRhMjIyMThlOWE0MDViYTI3NTdjMTg5M2FiNzA1ZGUzNjRjZDMzMWI0ZGM3MTMxMjQ5ZTJhMmE3YmQ5YmUw",
+    "Op": {
+      "inputs": [
+        {
+          "digest": "sha256:984a22218e9a405ba2757c1893ab705de364cd331b4dc7131249e2a2a7bd9be0",
+          "index": 0
+        }
+      ],
+      "Op": null
+    },
+    "Digest": "sha256:2b983ea2d58b029f550de8b7956aa8d180c41bcc06b3ee9ecd516aecebb5078e",
+    "OpMetadata": {
+      "caps": {
+        "constraints": true,
+        "meta.description": true,
+        "platform": true
+      }
+    }
+  },
+  {
+    "RawOp": "CkkKR3NoYTI1Njo2MzJiMTA1YWRjYzJlMmRkNjg1YjMyNTFlNzMxZjU5NzdiZWU4NDgyNjEyY2Y2M2ZmYmI5ZmFhZTY1ZDBiMmQ3IjESLxD///////////8BMiIKBC9hcHAQ6AMYASIKCgMQ6AcSAxDoByj///////////8BUg4KBWFtZDY0EgVsaW51eFoA",
+    "Op": {
+      "inputs": [
+        {
+          "digest": "sha256:632b105adcc2e2dd685b3251e731f5977bee8482612cf63ffbb9faae65d0b2d7",
+          "index": 0
+        }
+      ],
+      "Op": {
+        "File": {
+          "actions": [
+            {
+              "input": 0,
+              "secondaryInput": -1,
+              "output": 0,
+              "Action": {
+                "Mkdir": {
+                  "path": "/app",
+                  "mode": 488,
+                  "makeParents": true,
+                  "owner": {
+                    "user": {
+                      "User": {
+                        "ByID": 1000
+                      }
+                    },
+                    "group": {
+                      "User": {
+                        "ByID": 1000
+                      }
+                    }
+                  },
+                  "timestamp": -1
+                }
+              }
+            }
+          ]
+        }
+      },
+      "platform": {
+        "Architecture": "amd64",
+        "OS": "linux"
+      },
+      "constraints": {}
+    },
+    "Digest": "sha256:38e44d62e7241770644f543a940b432f2fb31b3402533c9d24654788fd4e9ec2",
+    "OpMetadata": {
+      "description": {
+        "llb.customname": "Mkdir /app"
+      },
+      "caps": {
+        "file.base": true
+      }
+    }
+  },
+  {
+    "RawOp": "CkkKR3NoYTI1NjpjNjY0YWZmODgxOTkwNjg0MzRiOGJmYjgxZjRkNjk0YWEyZGNjOGU5NTIxM2QxOTdjODdmNTlmZDY0NDMwZTUwErwBCrQBCgcvYmluL3NoCgItbwoHZXJyZXhpdAoCLWMKJ2FwayBhZGQgLS1uby1jYWNoZSBsaWJzYXNzLWRldj0zLjYuMy1yMRJBUEFUSD0vdXNyL2xvY2FsL3NiaW46L3Vzci9sb2NhbC9iaW46L3Vzci9zYmluOi91c3IvYmluOi9zYmluOi9iaW4SFE5PREVfVkVSU0lPTj0xMi4xNC4xEhNZQVJOX1ZFUlNJT049MS4yMS4xGgEvEgMaAS9SDgoFYW1kNjQSBWxpbnV4WgA=",
+    "Op": {
+      "inputs": [
+        {
+          "digest": "sha256:c664aff88199068434b8bfb81f4d694aa2dcc8e95213d197c87f59fd64430e50",
+          "index": 0
+        }
+      ],
+      "Op": {
+        "Exec": {
+          "meta": {
+            "args": [
+              "/bin/sh",
+              "-o",
+              "errexit",
+              "-c",
+              "apk add --no-cache libsass-dev=3.6.3-r1"
+            ],
+            "env": [
+              "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+              "NODE_VERSION=12.14.1",
+              "YARN_VERSION=1.21.1"
+            ],
+            "cwd": "/"
+          },
+          "mounts": [
+            {
+              "input": 0,
+              "dest": "/",
+              "output": 0
+            }
+          ]
+        }
+      },
+      "platform": {
+        "Architecture": "amd64",
+        "OS": "linux"
+      },
+      "constraints": {}
+    },
+    "Digest": "sha256:632b105adcc2e2dd685b3251e731f5977bee8482612cf63ffbb9faae65d0b2d7",
+    "OpMetadata": {
+      "description": {
+        "llb.customname": "Install system packages (libsass-dev=3.6.3-r1)"
+      },
+      "caps": {
+        "exec.meta.base": true,
+        "exec.mount.bind": true
+      }
+    }
+  },
+  {
+    "RawOp": "CkkKR3NoYTI1NjplMTk5MDAxMzMxNGYwOWUzNWMyYWNkNTc2ZWUxNGIzZmMzNTM0YjAyNWM3ZWUxMWVjZGE3OTdlNWM5ZWQzZGNkCkkKR3NoYTI1Njo5YjJhMDlmYWQ2Mzk5YWEwOTRiZjU3ODBlNTA5MzI5OTA1MjE4YzExODc4NjMyODBlZmMzYTdjMzk1ODQ0OTg5IkMSQRABIj0KCi95YXJuLmxvY2sSBS9hcHAvGgoKAxDoBxIDEOgHIP///////////wEoATABQAFIAVj///////////8BUg4KBWFtZDY0EgVsaW51eFoA",
+    "Op": {
+      "inputs": [
+        {
+          "digest": "sha256:e1990013314f09e35c2acd576ee14b3fc3534b025c7ee11ecda797e5c9ed3dcd",
+          "index": 0
+        },
+        {
+          "digest": "sha256:9b2a09fad6399aa094bf5780e509329905218c1187863280efc3a7c395844989",
+          "index": 0
+        }
+      ],
+      "Op": {
+        "File": {
+          "actions": [
+            {
+              "input": 0,
+              "secondaryInput": 1,
+              "output": 0,
+              "Action": {
+                "Copy": {
+                  "src": "/yarn.lock",
+                  "dest": "/app/",
+                  "owner": {
+                    "user": {
+                      "User": {
+                        "ByID": 1000
+                      }
+                    },
+                    "group": {
+                      "User": {
+                        "ByID": 1000
+                      }
+                    }
+                  },
+                  "mode": -1,
+                  "followSymlink": true,
+                  "dirCopyContents": true,
+                  "createDestPath": true,
+                  "allowWildcard": true,
+                  "timestamp": -1
+                }
+              }
+            }
+          ]
+        }
+      },
+      "platform": {
+        "Architecture": "amd64",
+        "OS": "linux"
+      },
+      "constraints": {}
+    },
+    "Digest": "sha256:7fa1ad8a8aa03ca75f5ef2db75f5337e4c138f4c0eb5804e6fe4a7d809f174d3",
+    "OpMetadata": {
+      "description": {
+        "llb.customname": "Copy yarn.lock"
+      },
+      "caps": {
+        "file.base": true
+      }
+    }
+  },
+  {
+    "RawOp": "CkkKR3NoYTI1Njo3ZmExYWQ4YThhYTAzY2E3NWY1ZWYyZGI3NWY1MzM3ZTRjMTM4ZjRjMGViNTgwNGU2ZmU0YTdkODA5ZjE3NGQzErwBCrQBCgcvYmluL3NoCgItbwoHZXJyZXhpdAoCLWMKHnlhcm4gaW5zdGFsbCAtLWZyb3plbi1sb2NrZmlsZRJBUEFUSD0vdXNyL2xvY2FsL3NiaW46L3Vzci9sb2NhbC9iaW46L3Vzci9zYmluOi91c3IvYmluOi9zYmluOi9iaW4SFE5PREVfVkVSU0lPTj0xMi4xNC4xEhNZQVJOX1ZFUlNJT049MS4yMS4xGgQvYXBwIgQxMDAwEgMaAS9SDgoFYW1kNjQSBWxpbnV4WgA=",
+    "Op": {
+      "inputs": [
+        {
+          "digest": "sha256:7fa1ad8a8aa03ca75f5ef2db75f5337e4c138f4c0eb5804e6fe4a7d809f174d3",
+          "index": 0
+        }
+      ],
+      "Op": {
+        "Exec": {
+          "meta": {
+            "args": [
+              "/bin/sh",
+              "-o",
+              "errexit",
+              "-c",
+              "yarn install --frozen-lockfile"
+            ],
+            "env": [
+              "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+              "NODE_VERSION=12.14.1",
+              "YARN_VERSION=1.21.1"
+            ],
+            "cwd": "/app",
+            "user": "1000"
+          },
+          "mounts": [
+            {
+              "input": 0,
+              "dest": "/",
+              "output": 0
+            }
+          ]
+        }
+      },
+      "platform": {
+        "Architecture": "amd64",
+        "OS": "linux"
+      },
+      "constraints": {}
+    },
+    "Digest": "sha256:8479565d6905288a88c92359c22d84e6725bf2931dd1be9c7ce6093f50a7eae7",
+    "OpMetadata": {
+      "description": {
+        "llb.customname": "Run yarn install"
+      },
+      "caps": {
+        "exec.meta.base": true,
+        "exec.mount.bind": true
+      }
+    }
+  },
+  {
+    "RawOp": "CkkKR3NoYTI1Njo4NDc5NTY1ZDY5MDUyODhhODhjOTIzNTljMjJkODRlNjcyNWJmMjkzMWRkMWJlOWM3Y2U2MDkzZjUwYTdlYWU3CkkKR3NoYTI1Njo5YjUxZTNhZDg2NmE1MWZjMWZiNzZlMmFkYTI0ZDNhZTgwNzQxOTkyNzllMjY1NTZkZDNhYzdkZmJlMTdkOWU2IjkSNxABIjMKAS8SBC9hcHAaCgoDEOgHEgMQ6Acg////////////ASgBMAFAAUgBWP///////////wFSDgoFYW1kNjQSBWxpbnV4WgA=",
+    "Op": {
+      "inputs": [
+        {
+          "digest": "sha256:8479565d6905288a88c92359c22d84e6725bf2931dd1be9c7ce6093f50a7eae7",
+          "index": 0
+        },
+        {
+          "digest": "sha256:9b51e3ad866a51fc1fb76e2ada24d3ae8074199279e26556dd3ac7dfbe17d9e6",
+          "index": 0
+        }
+      ],
+      "Op": {
+        "File": {
+          "actions": [
+            {
+              "input": 0,
+              "secondaryInput": 1,
+              "output": 0,
+              "Action": {
+                "Copy": {
+                  "src": "/",
+                  "dest": "/app",
+                  "owner": {
+                    "user": {
+                      "User": {
+                        "ByID": 1000
+                      }
+                    },
+                    "group": {
+                      "User": {
+                        "ByID": 1000
+                      }
+                    }
+                  },
+                  "mode": -1,
+                  "followSymlink": true,
+                  "dirCopyContents": true,
+                  "createDestPath": true,
+                  "allowWildcard": true,
+                  "timestamp": -1
+                }
+              }
+            }
+          ]
+        }
+      },
+      "platform": {
+        "Architecture": "amd64",
+        "OS": "linux"
+      },
+      "constraints": {}
+    },
+    "Digest": "sha256:984a22218e9a405ba2757c1893ab705de364cd331b4dc7131249e2a2a7bd9be0",
+    "OpMetadata": {
+      "description": {
+        "llb.customname": "Copy /"
+      },
+      "caps": {
+        "file.base": true
+      }
+    }
+  },
+  {
+    "RawOp": "GowBCg9sb2NhbDovL2NvbnRleHQSNAoUbG9jYWwuaW5jbHVkZXBhdHRlcm4SHFsicGFja2FnZS5qc29uIiwieWFybi5sb2NrIl0SHQoNbG9jYWwuc2Vzc2lvbhIMPFNFU1NJT04tSUQ+EiQKE2xvY2FsLnNoYXJlZGtleWhpbnQSDXBhY2thZ2UtZmlsZXNaAA==",
+    "Op": {
+      "Op": {
+        "Source": {
+          "identifier": "local://context",
+          "attrs": {
+            "local.includepattern": "[\"package.json\",\"yarn.lock\"]",
+            "local.session": "\u003cSESSION-ID\u003e",
+            "local.sharedkeyhint": "package-files"
+          }
+        }
+      },
+      "constraints": {}
+    },
+    "Digest": "sha256:9b2a09fad6399aa094bf5780e509329905218c1187863280efc3a7c395844989",
+    "OpMetadata": {
+      "description": {
+        "llb.customname": "load package.json and yarn.lock from build context"
+      },
+      "caps": {
+        "source.local": true,
+        "source.local.includepatterns": true,
+        "source.local.sessionid": true,
+        "source.local.sharedkeyhint": true
+      }
+    }
+  },
+  {
+    "RawOp": "GlYKD2xvY2FsOi8vY29udGV4dBIdCg1sb2NhbC5zZXNzaW9uEgw8U0VTU0lPTi1JRD4SJAoTbG9jYWwuc2hhcmVka2V5aGludBINYnVpbGQtY29udGV4dFoA",
+    "Op": {
+      "Op": {
+        "Source": {
+          "identifier": "local://context",
+          "attrs": {
+            "local.session": "\u003cSESSION-ID\u003e",
+            "local.sharedkeyhint": "build-context"
+          }
+        }
+      },
+      "constraints": {}
+    },
+    "Digest": "sha256:9b51e3ad866a51fc1fb76e2ada24d3ae8074199279e26556dd3ac7dfbe17d9e6",
+    "OpMetadata": {
+      "description": {
+        "llb.customname": "load build context"
+      },
+      "caps": {
+        "source.local": true,
+        "source.local.sessionid": true,
+        "source.local.sharedkeyhint": true
+      }
+    }
+  },
+  {
+    "RawOp": "GnkKd2RvY2tlci1pbWFnZTovL2RvY2tlci5pby9saWJyYXJ5L25vZGU6MTItYWxwaW5lQHNoYTI1NjoxZGQ0MzA5NDc5ZjAzMTI5NWYzZGZiNjFjZjNhZmMzZWZlYjFhOTkxYjAxMmUxMDVkMWE5NWVmYzAzOGI3MmY2Ug4KBWFtZDY0EgVsaW51eFoA",
+    "Op": {
+      "Op": {
+        "Source": {
+          "identifier": "docker-image://docker.io/library/node:12-alpine@sha256:1dd4309479f031295f3dfb61cf3afc3efeb1a991b012e105d1a95efc038b72f6"
+        }
+      },
+      "platform": {
+        "Architecture": "amd64",
+        "OS": "linux"
+      },
+      "constraints": {}
+    },
+    "Digest": "sha256:c664aff88199068434b8bfb81f4d694aa2dcc8e95213d197c87f59fd64430e50",
+    "OpMetadata": {
+      "caps": {
+        "source.image": true
+      }
+    }
+  },
+  {
+    "RawOp": "CkkKR3NoYTI1NjozOGU0NGQ2MmU3MjQxNzcwNjQ0ZjU0M2E5NDBiNDMyZjJmYjMxYjM0MDI1MzNjOWQyNDY1NDc4OGZkNGU5ZWMyCkkKR3NoYTI1Njo5YjJhMDlmYWQ2Mzk5YWEwOTRiZjU3ODBlNTA5MzI5OTA1MjE4YzExODc4NjMyODBlZmMzYTdjMzk1ODQ0OTg5IkYSRBABIkAKDS9wYWNrYWdlLmpzb24SBS9hcHAvGgoKAxDoBxIDEOgHIP///////////wEoATABQAFIAVj///////////8BUg4KBWFtZDY0EgVsaW51eFoA",
+    "Op": {
+      "inputs": [
+        {
+          "digest": "sha256:38e44d62e7241770644f543a940b432f2fb31b3402533c9d24654788fd4e9ec2",
+          "index": 0
+        },
+        {
+          "digest": "sha256:9b2a09fad6399aa094bf5780e509329905218c1187863280efc3a7c395844989",
+          "index": 0
+        }
+      ],
+      "Op": {
+        "File": {
+          "actions": [
+            {
+              "input": 0,
+              "secondaryInput": 1,
+              "output": 0,
+              "Action": {
+                "Copy": {
+                  "src": "/package.json",
+                  "dest": "/app/",
+                  "owner": {
+                    "user": {
+                      "User": {
+                        "ByID": 1000
+                      }
+                    },
+                    "group": {
+                      "User": {
+                        "ByID": 1000
+                      }
+                    }
+                  },
+                  "mode": -1,
+                  "followSymlink": true,
+                  "dirCopyContents": true,
+                  "createDestPath": true,
+                  "allowWildcard": true,
+                  "timestamp": -1
+                }
+              }
+            }
+          ]
+        }
+      },
+      "platform": {
+        "Architecture": "amd64",
+        "OS": "linux"
+      },
+      "constraints": {}
+    },
+    "Digest": "sha256:e1990013314f09e35c2acd576ee14b3fc3534b025c7ee11ecda797e5c9ed3dcd",
+    "OpMetadata": {
+      "description": {
+        "llb.customname": "Copy package.json"
+      },
+      "caps": {
+        "file.base": true
+      }
+    }
+  }
+]

--- a/pkg/defkinds/nodejs/testdata/debug-config/dump-dev.yml
+++ b/pkg/defkinds/nodejs/testdata/debug-config/dump-dev.yml
@@ -18,6 +18,10 @@ dev: true
 isfrontend: true
 deflocks:
   baseimage: docker.io/library/node:12-buster-slim
+  osrelease:
+    name: ""
+    versionname: ""
+    versionid: ""
   stages: {}
   sourcecontext: null
 stagelocks:

--- a/pkg/defkinds/nodejs/testdata/debug-config/dump-prod.yml
+++ b/pkg/defkinds/nodejs/testdata/debug-config/dump-prod.yml
@@ -14,6 +14,10 @@ dev: false
 isfrontend: true
 deflocks:
   baseimage: docker.io/library/node:12-buster-slim
+  osrelease:
+    name: ""
+    versionname: ""
+    versionid: ""
   stages: {}
   sourcecontext: null
 stagelocks:

--- a/pkg/defkinds/nodejs/testdata/locks/alpine.lock
+++ b/pkg/defkinds/nodejs/testdata/locks/alpine.lock
@@ -1,0 +1,13 @@
+base: docker.io/library/node:12-alpine@sha256
+osrelease:
+  name: alpine
+  versionname: ""
+  versionid: 3.10.3
+source_context: null
+stages:
+  dev:
+    system_packages:
+      libsass-dev: libsass-dev-version
+  prod:
+    system_packages:
+      libsass-dev: libsass-dev-version

--- a/pkg/defkinds/nodejs/testdata/locks/with-webserver.lock
+++ b/pkg/defkinds/nodejs/testdata/locks/with-webserver.lock
@@ -1,6 +1,0 @@
-base: docker.io/library/node:12-buster-slim
-stages:
-  dev:
-    system_packages: {}
-  prod:
-    system_packages: {}

--- a/pkg/defkinds/nodejs/testdata/locks/with-webserver.yml
+++ b/pkg/defkinds/nodejs/testdata/locks/with-webserver.yml
@@ -1,8 +1,0 @@
-kind: nodejs
-version: 12
-frontend: true
-
-webserver:
-  type: nginx
-  config_file: nginx.conf
-  healthcheck: true

--- a/pkg/defkinds/nodejs/testdata/locks/without-stages.lock
+++ b/pkg/defkinds/nodejs/testdata/locks/without-stages.lock
@@ -1,4 +1,8 @@
 base: docker.io/library/node:12-buster-slim@sha256
+osrelease:
+  name: debian
+  versionname: buster
+  versionid: "10"
 source_context: null
 stages:
   dev:

--- a/pkg/llbutils/utils.go
+++ b/pkg/llbutils/utils.go
@@ -62,7 +62,7 @@ func ReadFile(ctx context.Context, ref client.Reference, filepath string) ([]byt
 	content, err := ref.ReadFile(ctx, client.ReadRequest{
 		Filename: filepath,
 	})
-	if err != nil && strings.Contains(err.Error(), "file does not exist") {
+	if err != nil && strings.Contains(err.Error(), "no such file or directory") {
 		return []byte{}, false, nil
 	} else if err != nil {
 		return []byte{}, false, err

--- a/pkg/pkgsolver/pkgsolver.go
+++ b/pkg/pkgsolver/pkgsolver.go
@@ -2,6 +2,7 @@ package pkgsolver
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	"github.com/NiR-/zbuild/pkg/statesolver"
@@ -43,7 +44,10 @@ func (pkgSolvers PackageSolversMap) New(
 	solverType SolverType,
 	solver statesolver.StateSolver,
 ) PackageSolver {
-	factory := pkgSolvers[solverType]
+	factory, ok := pkgSolvers[solverType]
+	if !ok {
+		panic(fmt.Sprintf("No package solver %q found.", solverType))
+	}
 	return factory(solver)
 }
 

--- a/pkg/statesolver/buildkit.go
+++ b/pkg/statesolver/buildkit.go
@@ -79,7 +79,7 @@ func (s BuildkitSolver) FromContext(
 	return func(ctx context.Context, filepath string) ([]byte, error) {
 		raw, err := s.readFromLLB(ctx, src, filepath)
 		if err != nil {
-			return raw, xerrors.Errorf("failed to read %s from build context: %w", filepath, err)
+			return raw, xerrors.Errorf("failed to read %s from context: %w", filepath, err)
 		}
 
 		return raw, nil
@@ -123,7 +123,7 @@ func (s BuildkitSolver) FileExists(
 	source *builddef.Context,
 ) (bool, error) {
 	_, err := s.ReadFile(ctx, filepath, s.FromContext(source))
-	if err == FileNotFound {
+	if xerrors.Is(err, FileNotFound) {
 		return false, nil
 	}
 	return true, err

--- a/pkg/statesolver/buildkit_test.go
+++ b/pkg/statesolver/buildkit_test.go
@@ -97,7 +97,7 @@ func initFromGitContextTC(t *testing.T, mockCtrl *gomock.Controller) buildkitRea
 	}
 }
 
-func initFailToReadFileFromBuildContextTC(t *testing.T, mockCtrl *gomock.Controller) buildkitReadFileTC {
+func initFailToReadFileFromContextTC(t *testing.T, mockCtrl *gomock.Controller) buildkitReadFileTC {
 	contextRef := llbtest.NewMockReference(mockCtrl)
 	solved := &client.Result{
 		Refs: map[string]client.Reference{
@@ -117,7 +117,7 @@ func initFailToReadFileFromBuildContextTC(t *testing.T, mockCtrl *gomock.Control
 
 	contextRef.EXPECT().ReadFile(gomock.Any(), client.ReadRequest{
 		Filename: "/foo",
-	}).Return([]byte{}, xerrors.New("file does not exist"))
+	}).Return([]byte{}, xerrors.New("no such file or directory"))
 
 	solver := statesolver.NewBuildkitSolver(c)
 	opt := solver.FromContext(&builddef.Context{
@@ -128,7 +128,7 @@ func initFailToReadFileFromBuildContextTC(t *testing.T, mockCtrl *gomock.Control
 		solver:      solver,
 		opt:         opt,
 		filepath:    "/foo",
-		expectedErr: xerrors.Errorf("failed to read /foo from build context: %w", statesolver.FileNotFound),
+		expectedErr: xerrors.Errorf("failed to read /foo from context: %w", statesolver.FileNotFound),
 	}
 }
 
@@ -196,7 +196,7 @@ func initFailToReadNonexistantFileFromImageTC(t *testing.T, mockCtrl *gomock.Con
 		solver:      solver,
 		opt:         opt,
 		filepath:    "/foo",
-		expectedErr: xerrors.Errorf("failed to read /foo from docker.io/library/debian:buster: file not found"),
+		expectedErr: xerrors.Errorf("failed to read /foo from docker.io/library/debian:buster: file does not exist"),
 	}
 }
 
@@ -225,7 +225,7 @@ func TestBuildkitReadFile(t *testing.T) {
 	testcases := map[string]func(*testing.T, *gomock.Controller) buildkitReadFileTC{
 		"from build context":                         initFromBuildContextTC,
 		"from git context":                           initFromGitContextTC,
-		"fail to read file from build context":       initFailToReadFileFromBuildContextTC,
+		"fail to read file from context":             initFailToReadFileFromContextTC,
 		"from image":                                 initFromImageTC,
 		"fail to read a nonexistant file from image": initFailToReadNonexistantFileFromImageTC,
 		"fail to read from nonexistant image":        initFailToReadFromNonexistantImageTC,
@@ -328,7 +328,7 @@ func initBuildkitReportErrorWhenResultFileDoesntExistTC(mockCtrl *gomock.Control
 		Times(1).
 		Return(solved, nil)
 
-	err := xerrors.New("file does not exist")
+	err := xerrors.New("no such file or directory")
 	srcRef.EXPECT().ReadFile(gomock.Any(), client.ReadRequest{
 		Filename: "/tmp/result",
 	}).Times(1).Return([]byte{}, err)


### PR DESCRIPTION
Like for PHP, nodejs definitions now has an `alpine` parameter that can
be used in combination with `version` to let zbuild pick an alpine-based
base image.