### PR TITLE
Add Alpine support to webserver defs

### DIFF
--- a/examples/api-platform-demo/admin/zbuild.lock
+++ b/examples/api-platform-demo/admin/zbuild.lock
@@ -1,4 +1,4 @@
-base: docker.io/library/node:12-alpine@sha256:1dd4309479f031295f3dfb61cf3afc3efeb1a991b012e105d1a95efc038b72f6
+base: docker.io/library/node:12-alpine@sha256:bba77d0ca8820b43af898b3c50d4e8b68dc703ebbd958319af2f21f2d3c309f5
 osrelease:
   name: alpine
   versionname: ""
@@ -14,6 +14,10 @@ stages:
   prod:
     system_packages: {}
 webserver:
-  base_image: docker.io/library/nginx:latest@sha256:ad5552c786f128e389a0263104ae39f3d3c7895579d45ae716f528185b36bc6f
+  base_image: docker.io/library/nginx:alpine@sha256:9e81b8f9cef5a095f892183688798a5b2c368663276aa0f2be4b1cd283ace53d
+  osrelease:
+    name: alpine
+    versionname: ""
+    versionid: 3.10.4
   system_packages:
-    curl: 7.64.0-4
+    curl: 7.66.0-r0

--- a/examples/api-platform-demo/admin/zbuild.yml
+++ b/examples/api-platform-demo/admin/zbuild.yml
@@ -1,4 +1,4 @@
-# syntax=akerouanton/zbuilder:200208-04
+# syntax=akerouanton/zbuilder:200229-01
 kind: nodejs
 version: 12
 alpine: true
@@ -20,6 +20,7 @@ config_files:
 
 webserver:
   type: nginx
+  alpine: true
   config_file: nginx.conf
   assets:
     - from: build/

--- a/examples/api-platform-demo/api/zbuild.lock
+++ b/examples/api-platform-demo/api/zbuild.lock
@@ -1,4 +1,4 @@
-base_image: docker.io/library/php:7.3-fpm-alpine@sha256:c66cb88c90252cfe74491ec5685faf39672ea759aea16a86500242e71c0ce1a7
+base_image: docker.io/library/php:7.3-fpm-alpine@sha256:4d45b0b73aac6f9ecf7516cade9ccb601be96fb3ad59f0b7ecc344353a169932
 extension_dir: /usr/local/lib/php/extensions/no-debug-non-zts-20180731
 osrelease:
   name: alpine
@@ -20,9 +20,9 @@ stages:
     system_packages:
       git: 2.24.1-r0
       icu-dev: 64.2-r0
-      libxml2-dev: 2.9.10-r1
+      libxml2-dev: 2.9.10-r2
       libzip-dev: 1.5.2-r0
-      postgresql-dev: 12.1-r0
+      postgresql-dev: 12.2-r0
       unzip: 6.0-r4
   dev:
     extensions:
@@ -32,9 +32,9 @@ stages:
     system_packages:
       git: 2.24.1-r0
       icu-dev: 64.2-r0
-      libxml2-dev: 2.9.10-r1
+      libxml2-dev: 2.9.10-r2
       libzip-dev: 1.5.2-r0
-      postgresql-dev: 12.1-r0
+      postgresql-dev: 12.2-r0
       unzip: 6.0-r4
   prod:
     extensions:
@@ -46,11 +46,15 @@ stages:
     system_packages:
       git: 2.24.1-r0
       icu-dev: 64.2-r0
-      libxml2-dev: 2.9.10-r1
+      libxml2-dev: 2.9.10-r2
       libzip-dev: 1.5.2-r0
-      postgresql-dev: 12.1-r0
+      postgresql-dev: 12.2-r0
       unzip: 6.0-r4
 webserver:
-  base_image: docker.io/library/nginx:latest@sha256:ad5552c786f128e389a0263104ae39f3d3c7895579d45ae716f528185b36bc6f
+  base_image: docker.io/library/nginx:alpine@sha256:9e81b8f9cef5a095f892183688798a5b2c368663276aa0f2be4b1cd283ace53d
+  osrelease:
+    name: alpine
+    versionname: ""
+    versionid: 3.10.4
   system_packages:
-    curl: 7.64.0-4
+    curl: 7.66.0-r0

--- a/examples/api-platform-demo/api/zbuild.yml
+++ b/examples/api-platform-demo/api/zbuild.yml
@@ -1,4 +1,4 @@
-# syntax=akerouanton/zbuilder:200203-01
+# syntax=akerouanton/zbuilder:200229-01
 kind: php
 version: 7.3
 alpine: true
@@ -54,6 +54,7 @@ stages:
 
 webserver:
   type: nginx
+  alpine: true
   config_file: nginx.conf
   assets:
     - from: public/

--- a/examples/api-platform-demo/client/zbuild.lock
+++ b/examples/api-platform-demo/client/zbuild.lock
@@ -1,4 +1,4 @@
-base: docker.io/library/node:12-alpine@sha256:1dd4309479f031295f3dfb61cf3afc3efeb1a991b012e105d1a95efc038b72f6
+base: docker.io/library/node:12-alpine@sha256:bba77d0ca8820b43af898b3c50d4e8b68dc703ebbd958319af2f21f2d3c309f5
 osrelease:
   name: alpine
   versionname: ""
@@ -14,6 +14,10 @@ stages:
   prod:
     system_packages: {}
 webserver:
-  base_image: docker.io/library/nginx:latest@sha256:ad5552c786f128e389a0263104ae39f3d3c7895579d45ae716f528185b36bc6f
+  base_image: docker.io/library/nginx:alpine@sha256:9e81b8f9cef5a095f892183688798a5b2c368663276aa0f2be4b1cd283ace53d
+  osrelease:
+    name: alpine
+    versionname: ""
+    versionid: 3.10.4
   system_packages:
-    curl: 7.64.0-4
+    curl: 7.66.0-r0

--- a/examples/api-platform-demo/client/zbuild.yml
+++ b/examples/api-platform-demo/client/zbuild.yml
@@ -1,4 +1,4 @@
-# syntax=akerouanton/zbuilder:200208-04
+# syntax=akerouanton/zbuilder:200229-01
 kind: nodejs
 version: 12
 alpine: true
@@ -20,6 +20,7 @@ config_files:
 
 webserver:
   type: nginx
+  alpine: true
   config_file: nginx.conf
   assets:
     - from: build/

--- a/pkg/defkinds/webserver/builder.go
+++ b/pkg/defkinds/webserver/builder.go
@@ -63,7 +63,13 @@ func (h *WebserverHandler) Build(
 		return state, img, xerrors.New("no source state to copy assets from has been provided")
 	}
 
-	state, err = llbutils.InstallSystemPackages(state, llbutils.APT, def.Locks.SystemPackages)
+	pkgManager := llbutils.APT
+	if def.Locks.OSRelease.Name == "alpine" {
+		pkgManager = llbutils.APK
+	}
+
+	state, err = llbutils.InstallSystemPackages(state, pkgManager,
+		def.Locks.SystemPackages)
 	if err != nil {
 		return state, img, xerrors.Errorf("failed to add \"install system pacakges\" steps: %w", err)
 	}

--- a/pkg/defkinds/webserver/definition_test.go
+++ b/pkg/defkinds/webserver/definition_test.go
@@ -21,10 +21,12 @@ type newDefinitionTC struct {
 func initSuccessfullyParseRawDefinitionTC() newDefinitionTC {
 	configFile := "./docker/nginx.conf"
 	return newDefinitionTC{
-		file:     "testdata/locks/definition.yml",
-		lockFile: "testdata/locks/definition.lock",
+		file:     "testdata/def/definition.yml",
+		lockFile: "testdata/def/definition.lock",
 		expected: webserver.Definition{
 			Type:       "nginx",
+			Version:    "latest",
+			Alpine:     true,
 			ConfigFile: &configFile,
 			Healthcheck: &builddef.HealthcheckConfig{
 				HealthcheckHTTP: &builddef.HealthcheckHTTP{
@@ -46,7 +48,7 @@ func initSuccessfullyParseRawDefinitionTC() newDefinitionTC {
 				},
 			},
 			Locks: webserver.DefinitionLocks{
-				BaseImage: "docker.io/library/nginx:latest@sha256",
+				BaseImage: "docker.io/library/nginx:alpine@sha256",
 				SystemPackages: map[string]string{
 					"curl": "7.64.0-4",
 				},
@@ -403,6 +405,40 @@ func TestDefinitionMerge(t *testing.T) {
 					Assets: []webserver.AssetToCopy{
 						{From: "web/", To: "web/"},
 					},
+					SystemPackages: &builddef.VersionMap{},
+				}
+			},
+		},
+		"merge version with base": {
+			base: func() webserver.Definition {
+				return webserver.Definition{
+					Version: "latest",
+				}
+			},
+			overriding: func() webserver.Definition {
+				return webserver.Definition{
+					Version: "1.17.8",
+				}
+			},
+			expected: func() webserver.Definition {
+				return webserver.Definition{
+					Version:        "1.17.8",
+					SystemPackages: &builddef.VersionMap{},
+				}
+			},
+		},
+		"merge version without base": {
+			base: func() webserver.Definition {
+				return webserver.Definition{}
+			},
+			overriding: func() webserver.Definition {
+				return webserver.Definition{
+					Version: "1.17.8",
+				}
+			},
+			expected: func() webserver.Definition {
+				return webserver.Definition{
+					Version:        "1.17.8",
 					SystemPackages: &builddef.VersionMap{},
 				}
 			},

--- a/pkg/defkinds/webserver/locks_test.go
+++ b/pkg/defkinds/webserver/locks_test.go
@@ -69,10 +69,6 @@ func initSuccessfullyUpdateLocksTC(t *testing.T, mockCtrl *gomock.Controller) up
 }
 
 func TestUpdateLocks(t *testing.T) {
-	if *flagTestdata {
-		return
-	}
-
 	testcases := map[string]func(*testing.T, *gomock.Controller) updateLocksTC{
 		"successfully update locks": initSuccessfullyUpdateLocksTC,
 	}
@@ -112,6 +108,11 @@ func TestUpdateLocks(t *testing.T) {
 			rawLocks, err = yaml.Marshal(locks.RawLocks())
 			if err != nil {
 				t.Fatal(err)
+			}
+
+			if *flagTestdata {
+				writeTestdata(t, tc.expected, string(rawLocks))
+				return
 			}
 
 			expectedRaw := loadRawTestdata(t, tc.expected)

--- a/pkg/defkinds/webserver/testdata/build/alpine.json
+++ b/pkg/defkinds/webserver/testdata/build/alpine.json
@@ -1,0 +1,42 @@
+[
+  {
+    "RawOp": "Gn4KfGRvY2tlci1pbWFnZTovL2RvY2tlci5pby9saWJyYXJ5L25naW54OjEuMTcuNy1hbHBpbmVAc2hhMjU2OjA4YTIzMDQyOWMyZDI3YjhhNTY2ODE2M2YzYzIwZTczZTZiYmE2YWFkNDc5NmFhZWE5MDM3MmZiYWViY2ExMjJSDgoFYW1kNjQSBWxpbnV4WgA=",
+    "Op": {
+      "Op": {
+        "Source": {
+          "identifier": "docker-image://docker.io/library/nginx:1.17.7-alpine@sha256:08a230429c2d27b8a5668163f3c20e73e6bba6aad4796aaea90372fbaebca122"
+        }
+      },
+      "platform": {
+        "Architecture": "amd64",
+        "OS": "linux"
+      },
+      "constraints": {}
+    },
+    "Digest": "sha256:3027a1eb4dad10dd090ac1cba791af41547b52bbc08b88323cc2fb31bad52c09",
+    "OpMetadata": {
+      "caps": {
+        "source.image": true
+      }
+    }
+  },
+  {
+    "RawOp": "CkkKR3NoYTI1NjozMDI3YTFlYjRkYWQxMGRkMDkwYWMxY2JhNzkxYWY0MTU0N2I1MmJiYzA4Yjg4MzIzY2MyZmIzMWJhZDUyYzA5",
+    "Op": {
+      "inputs": [
+        {
+          "digest": "sha256:3027a1eb4dad10dd090ac1cba791af41547b52bbc08b88323cc2fb31bad52c09",
+          "index": 0
+        }
+      ],
+      "Op": null
+    },
+    "Digest": "sha256:958ea037dbd17c82201b6a88db5dc0630b960c30d513fded116613610400cde9",
+    "OpMetadata": {
+      "caps": {
+        "constraints": true,
+        "platform": true
+      }
+    }
+  }
+]

--- a/pkg/defkinds/webserver/testdata/build/alpine.lock
+++ b/pkg/defkinds/webserver/testdata/build/alpine.lock
@@ -1,0 +1,6 @@
+base_image: docker.io/library/nginx:1.17.7-alpine@sha256:08a230429c2d27b8a5668163f3c20e73e6bba6aad4796aaea90372fbaebca122
+osrelease:
+  name: alpine
+  versionname: ""
+  versionid: 3.10.3
+system_packages: {}

--- a/pkg/defkinds/webserver/testdata/build/alpine.yml
+++ b/pkg/defkinds/webserver/testdata/build/alpine.yml
@@ -1,0 +1,6 @@
+kind: webserver
+type: nginx
+version: 1.17.7
+alpine: true
+
+healthcheck: false

--- a/pkg/defkinds/webserver/testdata/def/definition.lock
+++ b/pkg/defkinds/webserver/testdata/def/definition.lock
@@ -1,0 +1,3 @@
+base_image: docker.io/library/nginx:alpine@sha256
+system_packages:
+  curl: 7.64.0-4

--- a/pkg/defkinds/webserver/testdata/def/definition.yml
+++ b/pkg/defkinds/webserver/testdata/def/definition.yml
@@ -1,0 +1,14 @@
+kind: webserver
+type: nginx
+version: latest
+alpine: true
+
+healthcheck: true
+system_packages:
+  curl: '*'
+
+config_file: ./docker/nginx.conf
+
+assets:
+  - from: /app/public
+    to: /app/public

--- a/pkg/defkinds/webserver/testdata/locks/definition.lock
+++ b/pkg/defkinds/webserver/testdata/locks/definition.lock
@@ -1,3 +1,7 @@
 base_image: docker.io/library/nginx:latest@sha256
+osrelease:
+  name: debian
+  versionname: buster
+  versionid: "10"
 system_packages:
   curl: 7.64.0-4


### PR DESCRIPTION
Like for PHP and NodeJS, webserver definitions now take an `alpine`
parameter to use either debian-based or alpine-based base images.