### PR TITLE
Support --no-cache CLI flag

### DIFF
--- a/pkg/builddef/build_opts.go
+++ b/pkg/builddef/build_opts.go
@@ -16,6 +16,7 @@ type BuildOpts struct {
 	// LocalUniqueID is useful mostly for test purpose, in order to use
 	// a predefine value and have stable op digests.
 	LocalUniqueID string
+	IgnoreCache   bool
 	File          string
 	LockFile      string
 	Stage         string

--- a/pkg/builddef/builddef.go
+++ b/pkg/builddef/builddef.go
@@ -132,3 +132,11 @@ func (set *VersionMap) Merge(overriding *VersionMap) {
 		set.Overwrite(name, val)
 	}
 }
+
+func (set *VersionMap) Size() int {
+	if set == nil {
+		return 0
+	}
+
+	return len(*set)
+}

--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -30,6 +30,7 @@ const (
 	keyContext       = "context"
 	keyDockerContext = "contextkey"
 	keyFilename      = "filename"
+	keyNoCache       = "no-cache"
 )
 
 // Builder takes a KindRegistry, which contains all the specialized handlers
@@ -83,6 +84,11 @@ func buildOptsFromBuildkitOpts(c client.Client) (builddef.BuildOpts, error) {
 		buildOpts.BuildContext, err = builddef.NewContext(v, "")
 	} else if v, ok := opts[keyContext]; ok {
 		buildOpts.BuildContext, err = builddef.NewContext(v, "")
+	}
+
+	// @TODO: support no-cache values (see https://sourcegraph.com/github.com/moby/buildkit@e0e3ad6/-/blob/frontend/dockerfile/builder/build.go#L110)
+	if _, ok := opts[keyNoCache]; ok {
+		buildOpts.IgnoreCache = true
 	}
 
 	return buildOpts, err

--- a/pkg/defkinds/php/extensions_test.go
+++ b/pkg/defkinds/php/extensions_test.go
@@ -98,7 +98,7 @@ func TestInstallExtensions(t *testing.T) {
 			tc := tcinit(t)
 
 			state := llb.Scratch()
-			res := php.InstallExtensions(state, tc.stageDef)
+			res := php.InstallExtensions(tc.stageDef, state, builddef.BuildOpts{})
 			jsonState := llbtest.StateToJSON(t, res)
 
 			if *flagTestdata {

--- a/pkg/defkinds/webserver/builder.go
+++ b/pkg/defkinds/webserver/builder.go
@@ -69,7 +69,8 @@ func (h *WebserverHandler) Build(
 	}
 
 	state, err = llbutils.InstallSystemPackages(state, pkgManager,
-		def.Locks.SystemPackages)
+		def.Locks.SystemPackages,
+		buildOpts.IgnoreCache)
 	if err != nil {
 		return state, img, xerrors.Errorf("failed to add \"install system pacakges\" steps: %w", err)
 	}
@@ -79,7 +80,8 @@ func (h *WebserverHandler) Build(
 	}
 
 	for _, asset := range def.Assets {
-		state = llbutils.Copy(*buildOpts.SourceState, asset.From, state, asset.To, fileOwner)
+		state = llbutils.Copy(
+			*buildOpts.SourceState, asset.From, state, asset.To, fileOwner, buildOpts.IgnoreCache)
 	}
 
 	setImageMetadata(def, state, img)
@@ -100,12 +102,9 @@ func (h *WebserverHandler) copyConfigFile(
 		llb.WithCustomName("load config file from build context"))
 
 	return llbutils.Copy(
-		configFileSrc,
-		*def.ConfigFile,
-		state,
-		def.Type.ConfigPath(),
-		fileOwner,
-	)
+		configFileSrc, *def.ConfigFile,
+		state, def.Type.ConfigPath(), fileOwner,
+		buildOpts.IgnoreCache)
 }
 
 func setImageMetadata(

--- a/pkg/llbutils/testdata/copy-without-cache.json
+++ b/pkg/llbutils/testdata/copy-without-cache.json
@@ -1,0 +1,105 @@
+[
+  {
+    "RawOp": "CkkKR3NoYTI1NjpjMWFhZWU4YTM4YmE2ZGVjNjRkNWI4YzkxOWM3Y2Y2YmRkYzA0ZjBiZDE4NzYzNjc4MzQyZDMzYTI1YzA2ODQ0IlQSUgj///////////8BIkUKCy9ldGMvcGFzc3dkEgwvZXRjL3Bhc3N3ZDIaCgoDEOgHEgMQ6Acg////////////ASgBMAFAAUgBWP///////////wFSDgoFYW1kNjQSBWxpbnV4WgA=",
+    "Op": {
+      "inputs": [
+        {
+          "digest": "sha256:c1aaee8a38ba6dec64d5b8c919c7cf6bddc04f0bd18763678342d33a25c06844",
+          "index": 0
+        }
+      ],
+      "Op": {
+        "File": {
+          "actions": [
+            {
+              "input": -1,
+              "secondaryInput": 0,
+              "output": 0,
+              "Action": {
+                "Copy": {
+                  "src": "/etc/passwd",
+                  "dest": "/etc/passwd2",
+                  "owner": {
+                    "user": {
+                      "User": {
+                        "ByID": 1000
+                      }
+                    },
+                    "group": {
+                      "User": {
+                        "ByID": 1000
+                      }
+                    }
+                  },
+                  "mode": -1,
+                  "followSymlink": true,
+                  "dirCopyContents": true,
+                  "createDestPath": true,
+                  "allowWildcard": true,
+                  "timestamp": -1
+                }
+              }
+            }
+          ]
+        }
+      },
+      "platform": {
+        "Architecture": "amd64",
+        "OS": "linux"
+      },
+      "constraints": {}
+    },
+    "Digest": "sha256:29ed5b3c6092a918d7e41fa9ff1372df1c52529981dd8510a59294c0abfd903b",
+    "OpMetadata": {
+      "ignore_cache": true,
+      "description": {
+        "llb.customname": "Copy /etc/passwd"
+      },
+      "caps": {
+        "file.base": true
+      }
+    }
+  },
+  {
+    "RawOp": "CkkKR3NoYTI1NjoyOWVkNWIzYzYwOTJhOTE4ZDdlNDFmYTlmZjEzNzJkZjFjNTI1Mjk5ODFkZDg1MTBhNTkyOTRjMGFiZmQ5MDNi",
+    "Op": {
+      "inputs": [
+        {
+          "digest": "sha256:29ed5b3c6092a918d7e41fa9ff1372df1c52529981dd8510a59294c0abfd903b",
+          "index": 0
+        }
+      ],
+      "Op": null
+    },
+    "Digest": "sha256:4a0d9d58222245b9d66a77f00e90a25413e42b9a1708d004c84a5f7fa04e6c4e",
+    "OpMetadata": {
+      "caps": {
+        "constraints": true,
+        "meta.description": true,
+        "meta.ignorecache": true,
+        "platform": true
+      }
+    }
+  },
+  {
+    "RawOp": "GioKKGRvY2tlci1pbWFnZTovL2RvY2tlci5pby9saWJyYXJ5L3BocDo3LjJSDgoFYW1kNjQSBWxpbnV4WgA=",
+    "Op": {
+      "Op": {
+        "Source": {
+          "identifier": "docker-image://docker.io/library/php:7.2"
+        }
+      },
+      "platform": {
+        "Architecture": "amd64",
+        "OS": "linux"
+      },
+      "constraints": {}
+    },
+    "Digest": "sha256:c1aaee8a38ba6dec64d5b8c919c7cf6bddc04f0bd18763678342d33a25c06844",
+    "OpMetadata": {
+      "caps": {
+        "source.image": true
+      }
+    }
+  }
+]

--- a/pkg/llbutils/testdata/install-system-packages-without-cache.json
+++ b/pkg/llbutils/testdata/install-system-packages-without-cache.json
@@ -1,0 +1,92 @@
+[
+  {
+    "RawOp": "CkkKR3NoYTI1Njo4NTU2MjYxOTEwZDUxYWI2ZDM1OTdhNTM2NGQ1MjI3YWI1ZDBkM2E5MjYxMDNhNDc5MDYwNzA5NzYzNmZjMjBl",
+    "Op": {
+      "inputs": [
+        {
+          "digest": "sha256:8556261910d51ab6d3597a5364d5227ab5d0d3a926103a4790607097636fc20e",
+          "index": 0
+        }
+      ],
+      "Op": null
+    },
+    "Digest": "sha256:537d06760280de9b60e03d5546d8e0e1fad381b971c3bb718f02742ab785c7bb",
+    "OpMetadata": {
+      "caps": {
+        "constraints": true,
+        "meta.description": true,
+        "meta.ignorecache": true,
+        "platform": true
+      }
+    }
+  },
+  {
+    "RawOp": "CkkKR3NoYTI1NjpjMWFhZWU4YTM4YmE2ZGVjNjRkNWI4YzkxOWM3Y2Y2YmRkYzA0ZjBiZDE4NzYzNjc4MzQyZDMzYTI1YzA2ODQ0EtcBCs8BCgcvYmluL3NoCgItbwoHZXJyZXhpdAoCLWMKrwFhcHQtZ2V0IHVwZGF0ZTsgYXB0LWdldCBpbnN0YWxsIC15IC0tbm8taW5zdGFsbC1yZWNvbW1lbmRzIGNhLWNlcnRmaWNpYXRlcz1jYS1jZXJ0aWZpY2F0ZXMtdmVyc2lvbiBjdXJsPWN1cmwtdmVyc2lvbiB6bGliMWctZGV2PXpsaWIxZy1kZXYtdmVyc2lvbjsgcm0gLXJmIC92YXIvbGliL2FwdC9saXN0cy8qGgEvEgMaAS9SDgoFYW1kNjQSBWxpbnV4WgA=",
+    "Op": {
+      "inputs": [
+        {
+          "digest": "sha256:c1aaee8a38ba6dec64d5b8c919c7cf6bddc04f0bd18763678342d33a25c06844",
+          "index": 0
+        }
+      ],
+      "Op": {
+        "Exec": {
+          "meta": {
+            "args": [
+              "/bin/sh",
+              "-o",
+              "errexit",
+              "-c",
+              "apt-get update; apt-get install -y --no-install-recommends ca-certficiates=ca-certificates-version curl=curl-version zlib1g-dev=zlib1g-dev-version; rm -rf /var/lib/apt/lists/*"
+            ],
+            "cwd": "/"
+          },
+          "mounts": [
+            {
+              "input": 0,
+              "dest": "/",
+              "output": 0
+            }
+          ]
+        }
+      },
+      "platform": {
+        "Architecture": "amd64",
+        "OS": "linux"
+      },
+      "constraints": {}
+    },
+    "Digest": "sha256:8556261910d51ab6d3597a5364d5227ab5d0d3a926103a4790607097636fc20e",
+    "OpMetadata": {
+      "ignore_cache": true,
+      "description": {
+        "llb.customname": "Install system packages (ca-certficiates=ca-certificates-version, curl=curl-version, zlib1g-dev=zlib1g-dev-version)"
+      },
+      "caps": {
+        "exec.meta.base": true,
+        "exec.mount.bind": true
+      }
+    }
+  },
+  {
+    "RawOp": "GioKKGRvY2tlci1pbWFnZTovL2RvY2tlci5pby9saWJyYXJ5L3BocDo3LjJSDgoFYW1kNjQSBWxpbnV4WgA=",
+    "Op": {
+      "Op": {
+        "Source": {
+          "identifier": "docker-image://docker.io/library/php:7.2"
+        }
+      },
+      "platform": {
+        "Architecture": "amd64",
+        "OS": "linux"
+      },
+      "constraints": {}
+    },
+    "Digest": "sha256:c1aaee8a38ba6dec64d5b8c919c7cf6bddc04f0bd18763678342d33a25c06844",
+    "OpMetadata": {
+      "caps": {
+        "source.image": true
+      }
+    }
+  }
+]

--- a/pkg/llbutils/utils_test.go
+++ b/pkg/llbutils/utils_test.go
@@ -214,7 +214,17 @@ func TestStateHelpers(t *testing.T) {
 			init: func(_ *testing.T) llb.State {
 				src := llbutils.ImageSource("php:7.2", false)
 				dest := llb.Scratch()
-				return llbutils.Copy(src, "/etc/passwd", dest, "/etc/passwd2", "1000:1000")
+				return llbutils.Copy(
+					src, "/etc/passwd", dest, "/etc/passwd2", "1000:1000", false)
+			},
+		},
+		"Copy without cache": {
+			testdata: "testdata/copy-without-cache.json",
+			init: func(_ *testing.T) llb.State {
+				src := llbutils.ImageSource("php:7.2", false)
+				dest := llb.Scratch()
+				return llbutils.Copy(
+					src, "/etc/passwd", dest, "/etc/passwd2", "1000:1000", true)
 			},
 		},
 		"InstallSystemPackages": {
@@ -226,7 +236,23 @@ func TestStateHelpers(t *testing.T) {
 					"ca-certficiates": "ca-certificates-version",
 					"zlib1g-dev":      "zlib1g-dev-version",
 				}
-				state, err := llbutils.InstallSystemPackages(dest, llbutils.APT, locks)
+				state, err := llbutils.InstallSystemPackages(dest, llbutils.APT, locks, false)
+				if err != nil {
+					t.Fatal(err)
+				}
+				return state
+			},
+		},
+		"InstallSystemPackages without cache": {
+			testdata: "testdata/install-system-packages-without-cache.json",
+			init: func(t *testing.T) llb.State {
+				dest := llbutils.ImageSource("php:7.2", false)
+				locks := map[string]string{
+					"curl":            "curl-version",
+					"ca-certficiates": "ca-certificates-version",
+					"zlib1g-dev":      "zlib1g-dev-version",
+				}
+				state, err := llbutils.InstallSystemPackages(dest, llbutils.APT, locks, true)
 				if err != nil {
 					t.Fatal(err)
 				}


### PR DESCRIPTION
When --no-cache flag is passed to `docker buildx build` or
`buildctl build`, Buildkit passes a "no-cache" option. It's then the
responsibility of the Buildkit frontend to mark each and every Run/Copy
step with llb.IgnoreCache constraint.

This commit introduces a new field to builddef.BuildOpts named
IgnoreCache. The generic builder package takes care of setting this
value when the "no-cache" option is received. It's then the
responsibility of specialized kind handlers to use this value correctly.