### PR TITLE
Use a cache mount for JS dependencies

### DIFF
--- a/pkg/builddef/builddef.go
+++ b/pkg/builddef/builddef.go
@@ -57,6 +57,15 @@ type Locks interface {
 // values.
 type VersionMap map[string]string
 
+// Len returns the number of versions in the map or 0 if the map is nil.
+func (set *VersionMap) Len() int {
+	if set == nil {
+		return 0
+	}
+
+	return len(*set)
+}
+
 func (set *VersionMap) Add(name, val string) {
 	if set == nil {
 		return

--- a/pkg/defkinds/nodejs/builder_test.go
+++ b/pkg/defkinds/nodejs/builder_test.go
@@ -175,7 +175,7 @@ func initBuildLLBForWorkerStageTC(t *testing.T, mockCtrl *gomock.Controller) bui
 						"NODE_ENV=production",
 					},
 					// Following entrypoint is automatically defined by the
-					// base image. Maybe it should not be kept? :thinking:
+					// base image. Maybe it should not be kept? :thinking: @TODO
 					Entrypoint: []string{"docker-entrypoint.sh"},
 					Cmd:        []string{"bin/worker.js"},
 					Volumes:    map[string]struct{}{},
@@ -478,8 +478,8 @@ func initBuildLLBForAlpineBasedBaseImageTC(t *testing.T, mockCtrl *gomock.Contro
 }
 
 func initBuildLLBForWorkerStageWithCacheMountsTC(t *testing.T, mockCtrl *gomock.Controller) buildTC {
-	genericDef := loadBuildDef(t, "testdata/build/zbuild.yml")
-	genericDef.RawLocks = loadDefLocks(t, "testdata/build/zbuild.lock")
+	genericDef := loadBuildDef(t, "testdata/build/with-cache-mounts.yml")
+	genericDef.RawLocks = loadDefLocks(t, "testdata/build/with-cache-mounts.lock")
 
 	solver := mocks.NewMockStateSolver(mockCtrl)
 	solver.EXPECT().

--- a/pkg/defkinds/nodejs/testdata/build/state-worker-with-cache-mounts.json
+++ b/pkg/defkinds/nodejs/testdata/build/state-worker-with-cache-mounts.json
@@ -56,11 +56,32 @@
     }
   },
   {
-    "RawOp": "CkkKR3NoYTI1NjplYmU5NGQ2OTUzOTJmYmQxOGNkYzg2OWUwNTE0ODRkMDdkMTEwZmNjNzZjNTg1YzllZWNiZjI1ZTY0Y2E4OWU2CkkKR3NoYTI1Njo5YjUxZTNhZDg2NmE1MWZjMWZiNzZlMmFkYTI0ZDNhZTgwNzQxOTkyNzllMjY1NTZkZDNhYzdkZmJlMTdkOWU2IjkSNxABIjMKAS8SBC9hcHAaCgoDEOgHEgMQ6Acg////////////ASgBMAFAAUgBWP///////////wFSDgoFYW1kNjQSBWxpbnV4WgA=",
+    "RawOp": "Gn4KfGRvY2tlci1pbWFnZTovL2RvY2tlci5pby9saWJyYXJ5L25vZGU6MTItYnVzdGVyLXNsaW1Ac2hhMjU2OjRkMTAxNmVlZmM0ZTZkYzUyYmE5YmU2NTUwZGNiMjVhNmUxODI2MTE3NTA3ZTY1ZWRhMzY1MGQ2ZWIxOWYwNDJSDgoFYW1kNjQSBWxpbnV4WgA=",
+    "Op": {
+      "Op": {
+        "Source": {
+          "identifier": "docker-image://docker.io/library/node:12-buster-slim@sha256:4d1016eefc4e6dc52ba9be6550dcb25a6e1826117507e65eda3650d6eb19f042"
+        }
+      },
+      "platform": {
+        "Architecture": "amd64",
+        "OS": "linux"
+      },
+      "constraints": {}
+    },
+    "Digest": "sha256:4ca78bb138c955edf043d42a537908d0732092acdd344c3d6d7fc24511f5ff1d",
+    "OpMetadata": {
+      "caps": {
+        "source.image": true
+      }
+    }
+  },
+  {
+    "RawOp": "CkkKR3NoYTI1Njo4NTBlMWJjYTYwOTk5OTUxY2IwYjc5MjRiZGI0OTgxNmNlYTZlYjU1ZjQ5NDUwZDRmNzk4NzM1NmI1NTM2MDEyCkkKR3NoYTI1Njo5YjUxZTNhZDg2NmE1MWZjMWZiNzZlMmFkYTI0ZDNhZTgwNzQxOTkyNzllMjY1NTZkZDNhYzdkZmJlMTdkOWU2IjkSNxABIjMKAS8SBC9hcHAaCgoDEOgHEgMQ6Acg////////////ASgBMAFAAUgBWP///////////wFSDgoFYW1kNjQSBWxpbnV4WgA=",
     "Op": {
       "inputs": [
         {
-          "digest": "sha256:ebe94d695392fbd18cdc869e051484d07d110fcc76c585c9eecbf25e64ca89e6",
+          "digest": "sha256:850e1bca60999951cb0b7924bdb49816cea6eb55f49450d4f7987356b5536012",
           "index": 0
         },
         {
@@ -109,7 +130,7 @@
       },
       "constraints": {}
     },
-    "Digest": "sha256:485e3611d364b1e46e7018b9a1a05ffb057afaf05364a698ec93ff0986dd9c7f",
+    "Digest": "sha256:4dcfbd3cd31265c7e1708b5628acb3863136338696feed073af394cd0bdf1979",
     "OpMetadata": {
       "description": {
         "llb.customname": "Copy /"
@@ -120,11 +141,32 @@
     }
   },
   {
-    "RawOp": "Gn4KfGRvY2tlci1pbWFnZTovL2RvY2tlci5pby9saWJyYXJ5L25vZGU6MTItYnVzdGVyLXNsaW1Ac2hhMjU2OjRkMTAxNmVlZmM0ZTZkYzUyYmE5YmU2NTUwZGNiMjVhNmUxODI2MTE3NTA3ZTY1ZWRhMzY1MGQ2ZWIxOWYwNDJSDgoFYW1kNjQSBWxpbnV4WgA=",
+    "RawOp": "IjkSNwj///////////8BEP///////////wEyHwoGL2NhY2hlEOgDGAEiBQoDEOgHKP///////////wFSDgoFYW1kNjQSBWxpbnV4WgA=",
     "Op": {
       "Op": {
-        "Source": {
-          "identifier": "docker-image://docker.io/library/node:12-buster-slim@sha256:4d1016eefc4e6dc52ba9be6550dcb25a6e1826117507e65eda3650d6eb19f042"
+        "File": {
+          "actions": [
+            {
+              "input": -1,
+              "secondaryInput": -1,
+              "output": 0,
+              "Action": {
+                "Mkdir": {
+                  "path": "/cache",
+                  "mode": 488,
+                  "makeParents": true,
+                  "owner": {
+                    "user": {
+                      "User": {
+                        "ByID": 1000
+                      }
+                    }
+                  },
+                  "timestamp": -1
+                }
+              }
+            }
+          ]
         }
       },
       "platform": {
@@ -133,10 +175,103 @@
       },
       "constraints": {}
     },
-    "Digest": "sha256:4ca78bb138c955edf043d42a537908d0732092acdd344c3d6d7fc24511f5ff1d",
+    "Digest": "sha256:71ae3268efed0a1f77e52967b43d30c94c34d88c36a2b00683db2ca3da2f6d2a",
+    "OpMetadata": {
+      "description": {
+        "llb.customname": "Mkdir /cache"
+      },
+      "caps": {
+        "file.base": true
+      }
+    }
+  },
+  {
+    "RawOp": "CkkKR3NoYTI1Njo0ZGNmYmQzY2QzMTI2NWM3ZTE3MDhiNTYyOGFjYjM4NjMxMzYzMzg2OTZmZWVkMDczYWYzOTRjZDBiZGYxOTc5",
+    "Op": {
+      "inputs": [
+        {
+          "digest": "sha256:4dcfbd3cd31265c7e1708b5628acb3863136338696feed073af394cd0bdf1979",
+          "index": 0
+        }
+      ],
+      "Op": null
+    },
+    "Digest": "sha256:7c2e69c82f4258cf2e0b1e7cde4a135b85c27ae0ac831dd6416a61a078b72a93",
     "OpMetadata": {
       "caps": {
-        "source.image": true
+        "constraints": true,
+        "meta.description": true,
+        "platform": true
+      }
+    }
+  },
+  {
+    "RawOp": "CkkKR3NoYTI1NjpmNGRjZDM0NjE2MjlmMmE1MjEwMDUxMGIzNTIzOGYyOWNhMzNiZmU3YTQ4ZTc2MzQ5YzM2MDFkNjBiMWJiYWFiCkkKR3NoYTI1Njo3MWFlMzI2OGVmZWQwYTFmNzdlNTI5NjdiNDNkMzBjOTRjMzRkODhjMzZhMmIwMDY4M2RiMmNhM2RhMmY2ZDJhEpACCrQBCgcvYmluL3NoCgItbwoHZXJyZXhpdAoCLWMKHnlhcm4gaW5zdGFsbCAtLWZyb3plbi1sb2NrZmlsZRJBUEFUSD0vdXNyL2xvY2FsL3NiaW46L3Vzci9sb2NhbC9iaW46L3Vzci9zYmluOi91c3IvYmluOi9zYmluOi9iaW4SFE5PREVfVkVSU0lPTj0xMi4xNC4xEhNZQVJOX1ZFUlNJT049MS4yMS4xGgQvYXBwIgQxMDAwEgMaAS8SUggBEgYvY2FjaGUaFi9ob21lL25vZGUvLmNhY2hlL3lhcm4g////////////ATADogEgCh5jYWNoZS1ucy9ob21lL25vZGUvLmNhY2hlL3lhcm5SDgoFYW1kNjQSBWxpbnV4WgA=",
+    "Op": {
+      "inputs": [
+        {
+          "digest": "sha256:f4dcd3461629f2a52100510b35238f29ca33bfe7a48e76349c3601d60b1bbaab",
+          "index": 0
+        },
+        {
+          "digest": "sha256:71ae3268efed0a1f77e52967b43d30c94c34d88c36a2b00683db2ca3da2f6d2a",
+          "index": 0
+        }
+      ],
+      "Op": {
+        "Exec": {
+          "meta": {
+            "args": [
+              "/bin/sh",
+              "-o",
+              "errexit",
+              "-c",
+              "yarn install --frozen-lockfile"
+            ],
+            "env": [
+              "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+              "NODE_VERSION=12.14.1",
+              "YARN_VERSION=1.21.1"
+            ],
+            "cwd": "/app",
+            "user": "1000"
+          },
+          "mounts": [
+            {
+              "input": 0,
+              "dest": "/",
+              "output": 0
+            },
+            {
+              "input": 1,
+              "selector": "/cache",
+              "dest": "/home/node/.cache/yarn",
+              "output": -1,
+              "mountType": 3,
+              "cacheOpt": {
+                "ID": "cache-ns/home/node/.cache/yarn"
+              }
+            }
+          ]
+        }
+      },
+      "platform": {
+        "Architecture": "amd64",
+        "OS": "linux"
+      },
+      "constraints": {}
+    },
+    "Digest": "sha256:850e1bca60999951cb0b7924bdb49816cea6eb55f49450d4f7987356b5536012",
+    "OpMetadata": {
+      "description": {
+        "llb.customname": "Run yarn install"
+      },
+      "caps": {
+        "exec.meta.base": true,
+        "exec.mount.bind": true,
+        "exec.mount.cache": true,
+        "exec.mount.cache.sharing": true,
+        "exec.mount.selector": true
       }
     }
   },
@@ -191,79 +326,6 @@
         "source.local": true,
         "source.local.sessionid": true,
         "source.local.sharedkeyhint": true
-      }
-    }
-  },
-  {
-    "RawOp": "CkkKR3NoYTI1NjpmNGRjZDM0NjE2MjlmMmE1MjEwMDUxMGIzNTIzOGYyOWNhMzNiZmU3YTQ4ZTc2MzQ5YzM2MDFkNjBiMWJiYWFiErwBCrQBCgcvYmluL3NoCgItbwoHZXJyZXhpdAoCLWMKHnlhcm4gaW5zdGFsbCAtLWZyb3plbi1sb2NrZmlsZRJBUEFUSD0vdXNyL2xvY2FsL3NiaW46L3Vzci9sb2NhbC9iaW46L3Vzci9zYmluOi91c3IvYmluOi9zYmluOi9iaW4SFE5PREVfVkVSU0lPTj0xMi4xNC4xEhNZQVJOX1ZFUlNJT049MS4yMS4xGgQvYXBwIgQxMDAwEgMaAS9SDgoFYW1kNjQSBWxpbnV4WgA=",
-    "Op": {
-      "inputs": [
-        {
-          "digest": "sha256:f4dcd3461629f2a52100510b35238f29ca33bfe7a48e76349c3601d60b1bbaab",
-          "index": 0
-        }
-      ],
-      "Op": {
-        "Exec": {
-          "meta": {
-            "args": [
-              "/bin/sh",
-              "-o",
-              "errexit",
-              "-c",
-              "yarn install --frozen-lockfile"
-            ],
-            "env": [
-              "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
-              "NODE_VERSION=12.14.1",
-              "YARN_VERSION=1.21.1"
-            ],
-            "cwd": "/app",
-            "user": "1000"
-          },
-          "mounts": [
-            {
-              "input": 0,
-              "dest": "/",
-              "output": 0
-            }
-          ]
-        }
-      },
-      "platform": {
-        "Architecture": "amd64",
-        "OS": "linux"
-      },
-      "constraints": {}
-    },
-    "Digest": "sha256:ebe94d695392fbd18cdc869e051484d07d110fcc76c585c9eecbf25e64ca89e6",
-    "OpMetadata": {
-      "description": {
-        "llb.customname": "Run yarn install"
-      },
-      "caps": {
-        "exec.meta.base": true,
-        "exec.mount.bind": true
-      }
-    }
-  },
-  {
-    "RawOp": "CkkKR3NoYTI1Njo0ODVlMzYxMWQzNjRiMWU0NmU3MDE4YjlhMWEwNWZmYjA1N2FmYWYwNTM2NGE2OThlYzkzZmYwOTg2ZGQ5Yzdm",
-    "Op": {
-      "inputs": [
-        {
-          "digest": "sha256:485e3611d364b1e46e7018b9a1a05ffb057afaf05364a698ec93ff0986dd9c7f",
-          "index": 0
-        }
-      ],
-      "Op": null
-    },
-    "Digest": "sha256:eee5594ce9030ab282e5fc42815af3dc2f03c5618665a5f67f501dce8fe2baa0",
-    "OpMetadata": {
-      "caps": {
-        "constraints": true,
-        "meta.description": true,
-        "platform": true
       }
     }
   },

--- a/pkg/defkinds/nodejs/testdata/build/with-cache-mounts.lock
+++ b/pkg/defkinds/nodejs/testdata/build/with-cache-mounts.lock
@@ -1,0 +1,22 @@
+base: docker.io/library/node:12-buster-slim@sha256:4d1016eefc4e6dc52ba9be6550dcb25a6e1826117507e65eda3650d6eb19f042
+defhash: 16909497532092672513
+osrelease:
+  name: debian
+  versionname: buster
+  versionid: "10"
+source_context: null
+stages:
+  dev:
+    system_packages: {}
+  prod:
+    system_packages: {}
+  worker:
+    system_packages: {}
+webserver:
+  base_image: docker.io/library/nginx:latest@sha256:2539d4344dd18e1df02be842ffc435f8e1f699cfc55516e2cf2cb16b7a9aea0b
+  osrelease:
+    name: debian
+    versionname: buster
+    versionid: "10"
+  system_packages:
+    curl: 7.64.0-4+deb10u1

--- a/pkg/defkinds/nodejs/testdata/build/with-cache-mounts.yml
+++ b/pkg/defkinds/nodejs/testdata/build/with-cache-mounts.yml
@@ -1,0 +1,9 @@
+kind: nodejs
+version: 12
+
+stages:
+  prod:
+    healthcheck: false
+  worker:
+    from: prod
+    command: bin/worker.js


### PR DESCRIPTION
Like for system packages, JS dependencies can now be cached in a dedicated cache mount whenever yarn or npm run.