### PR TITLE
Limit the context used by FileExists to the path to check

### DIFF
--- a/cmd/zbuild/debug_config.go
+++ b/cmd/zbuild/debug_config.go
@@ -40,7 +40,7 @@ func HandleDebugConfigCmd(cmd *cobra.Command, args []string) {
 	b := builder.Builder{
 		Registry: registry.Registry,
 	}
-	solver := newDockerSolver(debugConfigFlags.context)
+	solver := newLocalSolver(debugConfigFlags.context)
 
 	dump, err := b.DumpConfig(solver,
 		debugConfigFlags.file,

--- a/cmd/zbuild/debug_llb.go
+++ b/cmd/zbuild/debug_llb.go
@@ -57,7 +57,7 @@ func HandleDebugLLBCmd(cmd *cobra.Command, args []string) {
 	b := builder.Builder{
 		Registry: registry.Registry,
 	}
-	solver := newDockerSolver(debugFlags.context)
+	solver := newLocalSolver(debugFlags.context)
 
 	state, err := b.Debug(solver, debugFlags.file, debugFlags.stage)
 	if err != nil {

--- a/cmd/zbuild/root.go
+++ b/cmd/zbuild/root.go
@@ -36,7 +36,7 @@ func main() {
 	}
 }
 
-func newDockerSolver(rootDir string) statesolver.DockerSolver {
+func newLocalSolver(rootDir string) statesolver.LocalSolver {
 	c, err := client.NewClientWithOpts(client.FromEnv)
 	if err != nil {
 		logrus.Fatalf("%+v", err)
@@ -52,7 +52,7 @@ func newDockerSolver(rootDir string) statesolver.DockerSolver {
 		}
 	}
 
-	return statesolver.DockerSolver{
+	return statesolver.LocalSolver{
 		Client:        c,
 		Labels:        map[string]string{},
 		RootDir:       rootDir,

--- a/cmd/zbuild/update.go
+++ b/cmd/zbuild/update.go
@@ -50,7 +50,7 @@ func HandleUpdateCmd(cmd *cobra.Command, args []string) {
 		BuildContext: buildctx,
 	}
 
-	solver := newDockerSolver(buildOpts.BuildContext.Source)
+	solver := newLocalSolver(buildOpts.BuildContext.Source)
 	b := builder.Builder{
 		Registry:   registry.Registry,
 		PkgSolvers: pkgsolver.DefaultPackageSolversMap,

--- a/pkg/pkgsolver/apk_test.go
+++ b/pkg/pkgsolver/apk_test.go
@@ -35,7 +35,7 @@ func TestAPKResolveVersions(t *testing.T) {
 			t.Parallel()
 
 			ctx := context.Background()
-			solver := statesolver.DockerSolver{
+			solver := statesolver.LocalSolver{
 				Client:  c,
 				Labels:  map[string]string{},
 				RootDir: "testdata",

--- a/pkg/pkgsolver/apt_test.go
+++ b/pkg/pkgsolver/apt_test.go
@@ -36,7 +36,7 @@ func TestAPTResolveVersions(t *testing.T) {
 			t.Parallel()
 
 			ctx := context.Background()
-			solver := statesolver.DockerSolver{
+			solver := statesolver.LocalSolver{
 				Client:  c,
 				Labels:  map[string]string{},
 				RootDir: "testdata",

--- a/pkg/statesolver/buildkit.go
+++ b/pkg/statesolver/buildkit.go
@@ -122,7 +122,25 @@ func (s BuildkitSolver) FileExists(
 	filepath string,
 	source *builddef.Context,
 ) (bool, error) {
-	_, err := s.ReadFile(ctx, filepath, s.FromContext(source))
+	// @TODO: switch to StatFile once it got fixed upstream (it currently fails the hard way if the given filepath does not exist).
+	/* src := llbutils.FromContext(source,
+		llb.IncludePatterns([]string{filepath}),
+		llb.SessionID(s.sessionID))
+	_, srcRef, err := llbutils.SolveState(ctx, s.client, src)
+	if err != nil {
+		return false, err
+	}
+
+	_, err = srcRef.StatFile(ctx, client.StatRequest{
+		Path: filepath,
+	})
+	if xerrors.Is(err, FileNotFound) {
+		return false, nil
+	}
+	return true, err */
+
+	_, err := s.ReadFile(ctx, filepath, s.FromContext(source,
+		llb.IncludePatterns([]string{filepath})))
 	if xerrors.Is(err, FileNotFound) {
 		return false, nil
 	}

--- a/pkg/statesolver/local_test.go
+++ b/pkg/statesolver/local_test.go
@@ -35,7 +35,7 @@ func newDockerClient(t *testing.T) *client.Client {
 	return c
 }
 
-func initFetchOSReleaseFromImageTC(t *testing.T, solver statesolver.DockerSolver) dockerReadFileTC {
+func initFetchOSReleaseFromImageTC(t *testing.T, solver statesolver.LocalSolver) dockerReadFileTC {
 	return dockerReadFileTC{
 		opt:  solver.FromImage(debianBusterSlimRef),
 		path: "/etc/os-release",
@@ -52,7 +52,7 @@ BUG_REPORT_URL="https://bugs.debian.org/"
 	}
 }
 
-func initFailToFetchNonexistantPathFromImageTC(t *testing.T, solver statesolver.DockerSolver) dockerReadFileTC {
+func initFailToFetchNonexistantPathFromImageTC(t *testing.T, solver statesolver.LocalSolver) dockerReadFileTC {
 	return dockerReadFileTC{
 		opt:  solver.FromImage(debianBusterSlimRef),
 		path: "/etc/nonexistant",
@@ -63,7 +63,7 @@ func initFailToFetchNonexistantPathFromImageTC(t *testing.T, solver statesolver.
 	}
 }
 
-func initPullImageAndReadFileFromImageTC(t *testing.T, solver statesolver.DockerSolver) dockerReadFileTC {
+func initPullImageAndReadFileFromImageTC(t *testing.T, solver statesolver.LocalSolver) dockerReadFileTC {
 	return dockerReadFileTC{
 		opt:  solver.FromImage("debian:bullseye-slim"),
 		path: "/etc/os-release",
@@ -77,7 +77,7 @@ BUG_REPORT_URL="https://bugs.debian.org/"
 	}
 }
 
-func initFailToFetchFromNonexistantImageTC(t *testing.T, solver statesolver.DockerSolver) dockerReadFileTC {
+func initFailToFetchFromNonexistantImageTC(t *testing.T, solver statesolver.LocalSolver) dockerReadFileTC {
 	return dockerReadFileTC{
 		opt:         solver.FromImage("akerouanton/nopenopenope"),
 		path:        "/etc/os-release",
@@ -85,7 +85,7 @@ func initFailToFetchFromNonexistantImageTC(t *testing.T, solver statesolver.Dock
 	}
 }
 
-func initDockerReadFileFromBuildContextTC(t *testing.T, solver statesolver.DockerSolver) dockerReadFileTC {
+func initDockerReadFileFromBuildContextTC(t *testing.T, solver statesolver.LocalSolver) dockerReadFileTC {
 	return dockerReadFileTC{
 		opt: solver.FromContext(&builddef.Context{
 			Type: builddef.ContextTypeLocal,
@@ -95,7 +95,7 @@ func initDockerReadFileFromBuildContextTC(t *testing.T, solver statesolver.Docke
 	}
 }
 
-func initFailToReadNonexistantFileFromBuildContextTC(t *testing.T, solver statesolver.DockerSolver) dockerReadFileTC {
+func initFailToReadNonexistantFileFromBuildContextTC(t *testing.T, solver statesolver.LocalSolver) dockerReadFileTC {
 	return dockerReadFileTC{
 		opt: solver.FromContext(&builddef.Context{
 			Type: builddef.ContextTypeLocal,
@@ -106,7 +106,7 @@ func initFailToReadNonexistantFileFromBuildContextTC(t *testing.T, solver states
 }
 
 func TestDockerReadFile(t *testing.T) {
-	testcases := map[string]func(*testing.T, statesolver.DockerSolver) dockerReadFileTC{
+	testcases := map[string]func(*testing.T, statesolver.LocalSolver) dockerReadFileTC{
 		"fetch /etc/os-release from image":                 initFetchOSReleaseFromImageTC,
 		"fail to fetch nonexistant path":                   initFailToFetchNonexistantPathFromImageTC,
 		"pull image and fetch /etc/os-release":             initPullImageAndReadFileFromImageTC,
@@ -125,7 +125,7 @@ func TestDockerReadFile(t *testing.T) {
 		t.Run(tcname, func(t *testing.T) {
 			t.Parallel()
 
-			solver := statesolver.DockerSolver{
+			solver := statesolver.LocalSolver{
 				Client:  c,
 				Labels:  map[string]string{},
 				RootDir: "testdata",
@@ -210,7 +210,7 @@ func TestDockerExecImage(t *testing.T) {
 		t.Run(tcname, func(t *testing.T) {
 			t.Parallel()
 
-			solver := statesolver.DockerSolver{
+			solver := statesolver.LocalSolver{
 				Client:  c,
 				Labels:  map[string]string{},
 				RootDir: "testdata",
@@ -256,7 +256,7 @@ func TestDockerResolveImageRef(t *testing.T) {
 		},
 	}
 
-	solver := statesolver.DockerSolver{
+	solver := statesolver.LocalSolver{
 		ImageResolver: docker.NewResolver(docker.ResolverOptions{}),
 	}
 
@@ -292,7 +292,7 @@ type dockerFileExistsTC struct {
 	expectedErr error
 }
 
-func TestDockerSolverFileExists(t *testing.T) {
+func TestLocalSolverFileExists(t *testing.T) {
 	testcases := map[string]dockerFileExistsTC{
 		"successfully check file exists": {
 			filepath: "testfile",
@@ -316,7 +316,7 @@ func TestDockerSolverFileExists(t *testing.T) {
 		t.Run(tcname, func(t *testing.T) {
 			t.Parallel()
 
-			solver := statesolver.DockerSolver{
+			solver := statesolver.LocalSolver{
 				Labels:  map[string]string{},
 				RootDir: "testdata",
 			}


### PR DESCRIPTION
So far, the FileExists method of statesolver.Buildkit was based on
reference.ReadFile() method, coming from Buildkit SDK. This method was
called against a reference based on the source/build context passed as
argument. However, the referenced state was including the whole context.
Because of that, Buildkit was randomly showing different context size
from one build to another.

Also, note that it'd be better to stat the path instead of reading it.
However, this commit led to discovering a bug in Buildkit: stating a
nonexistant file makes the frontend fail with an error message (whereas
the `ReadFile()` method is properly returning an os.IsNotExist error).